### PR TITLE
Fixes for Mi Smart Microwave (chunmi-n20l01)

### DIFF
--- a/lib/modules/oven/OvenAccessory.js
+++ b/lib/modules/oven/OvenAccessory.js
@@ -77,7 +77,7 @@ class OvenAccessory extends BaseAccessory {
 
   setOvenOn(state) {
     if (this.isMiotDeviceConnected()) {
-      this.getDevice().setCookigActive(state);
+      this.getDevice().setCookingActive(state);
     } else {
       throw new HapStatusError(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
     }

--- a/lib/modules/oven/OvenDevice.js
+++ b/lib/modules/oven/OvenDevice.js
@@ -108,7 +108,7 @@ class OvenDevice extends BaseDevice {
     return this.getStatus() === this.statusCompletedValue();
   }
 
-  async setCookigActive(active) {
+  async setCookingActive(active) {
     if (active) {
       this.fireAction(OvenActions.START_COOK);
     } else {

--- a/lib/modules/oven/devices/chunmi.microwave.n20l01.js
+++ b/lib/modules/oven/devices/chunmi.microwave.n20l01.js
@@ -61,6 +61,10 @@ class ChunmiMicrowaveN20l01 extends OvenDevice {
 
   /*----------========== CONFIG ==========----------*/
 
+  requiresMiCloud() {
+    return true;
+  }
+
   statusIdleValue() {
     return 1;
   }

--- a/lib/modules/oven/devices/chunmi.microwave.n20l01.js
+++ b/lib/modules/oven/devices/chunmi.microwave.n20l01.js
@@ -24,7 +24,7 @@ class ChunmiMicrowaveN20l01 extends OvenDevice {
 
     // READ ONLY
     this.addProperty(OvenProperties.LEFT_TIME, 2, 1, PropFormat.UINT16, PropAccess.READ_NOTIFY, PropUnit.SECONDS, [0, 3960, 1]);
-    this.addProperty(OvenProperties.STATUS, 2, 3, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.NONE, [], [{
+    this.addProperty(OvenProperties.STATUS, 2, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.NONE, [], [{
         "value": 1,
         "description": "Idle"
       },

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -80,4 +80,4 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 * hyd.airer.znlyj1 (MIJIA Smart Clothes Dryer)
 
 ### Oven
-* chunmi.microwave.n20l01 (Mi Smart Microwave Oven)
+* chunmi.microwave.n20l01 (Mi Smart Microwave Oven) 🔵[MiCloud]


### PR DESCRIPTION
- Fixes a typo in the SIID / PIID for oven status so the current state is correctly reflected.
- Requires MiCloud.
- Fixes minor spelling typo.

Toggling / controlling the microwave oven unfortunately still does not work, however.