### PR TITLE
Add support for the Xiaomi Mija Robot Vacuum 1T (dreame.vacuum.p2041)

### DIFF
--- a/lib/modules/robotcleaner/RobotCleanerActions.js
+++ b/lib/modules/robotcleaner/RobotCleanerActions.js
@@ -10,6 +10,7 @@ const RobotCleanerActions = {
   RESET_BRUSH_LIFE: 'reset_brush_life',
   RESET_SIDE_BRUSH_LIFE: 'reset_side_brush_life',
   START_CLEAN: 'start_clean',
+  ROOM_CLEAN: 'room_clean',
   STOP_CLEAN: 'stop_clean',
   PLAY_SOUND: 'play_sound',
   LOCATE_ROBOT: 'locate_robot'

--- a/lib/modules/robotcleaner/RobotCleanerFactory.js
+++ b/lib/modules/robotcleaner/RobotCleanerFactory.js
@@ -1,3 +1,4 @@
+const DreameVacuumP2041 = require('./devices/dreame.vacuum.p2041.js');
 const DreameVacuumP2008 = require('./devices/dreame.vacuum.p2008.js');
 const DreameVacuumMC1808 = require('./devices/dreame.vacuum.mc1808.js');
 const RoborockVacuumA15 = require('./devices/roborock.vacuum.a15.js');
@@ -13,7 +14,9 @@ class RobotCleanerFactory {
     let deviceFactoryClass = null;
 
     if (deviceModel) {
-      if (deviceModel.includes('dreame.vacuum.p2008')) {
+      if (deviceModel.includes('dreame.vacuum.p2041')) {
+        deviceFactoryClass = DreameVacuumP2041;
+      } else if (deviceModel.includes('dreame.vacuum.p2008')) {
         deviceFactoryClass = DreameVacuumP2008;
       } else if (deviceModel.includes('dreame.vacuum.mc1808')) {
         deviceFactoryClass = DreameVacuumMC1808;

--- a/lib/modules/robotcleaner/devices/dreame.vacuum.p2041.js
+++ b/lib/modules/robotcleaner/devices/dreame.vacuum.p2041.js
@@ -7,8 +7,7 @@ const PropUnit = require('../../../constants/PropUnit.js');
 const PropAccess = require('../../../constants/PropAccess.js');
 
 // Spec:
-// http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2008:1
-
+// http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2041:1
 
 class DreameVacuumP2041 extends RobotCleanerDevice {
   constructor(model, deviceId, name, logger) {

--- a/lib/modules/robotcleaner/devices/dreame.vacuum.p2041.js
+++ b/lib/modules/robotcleaner/devices/dreame.vacuum.p2041.js
@@ -1,0 +1,177 @@
+const RobotCleanerDevice = require('../RobotCleanerDevice.js');
+const RobotCleanerProperties = require('../RobotCleanerProperties.js');
+const RobotCleanerActions = require('../RobotCleanerActions.js');
+const Constants = require('../../../constants/Constants.js');
+const PropFormat = require('../../../constants/PropFormat.js');
+const PropUnit = require('../../../constants/PropUnit.js');
+const PropAccess = require('../../../constants/PropAccess.js');
+
+// Spec:
+// http://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:vacuum:0000A006:dreame-p2008:1
+
+
+class DreameVacuumP2041 extends RobotCleanerDevice {
+  constructor(model, deviceId, name, logger) {
+    super(model, deviceId, name, logger);
+  }
+
+
+  /*----------========== INIT ==========----------*/
+
+  initDeviceProperties() {
+    // READ/WRITE
+    this.addProperty(RobotCleanerProperties.MODE, 4, 4, PropFormat.INT8, PropAccess.READ_WRITE_NOTIFY, PropUnit.NONE, [], [{
+        "value": 0,
+        "description": "Silent"
+      },
+      {
+        "value": 1,
+        "description": "Standard"
+      },
+      {
+        "value": 2,
+        "description": "Medium"
+      },
+      {
+        "value": 3,
+        "description": "Turbo"
+      }
+    ]);
+    this.addProperty(RobotCleanerProperties.MOP_MODE, 4, 5, PropFormat.INT8, PropAccess.READ_WRITE_NOTIFY, PropUnit.NONE, [], [{
+        "value": 1,
+        "description": "Low water"
+      },
+      {
+        "value": 2,
+        "description": "Medium water"
+      },
+      {
+        "value": 3,
+        "description": "High water"
+      }
+    ]);
+    this.addProperty(RobotCleanerProperties.DO_NOT_DISTURB, 5, 1, PropFormat.BOOL, PropAccess.READ_WRITE_NOTIFY, PropUnit.NONE);
+
+    // READ ONLY
+    this.addProperty(RobotCleanerProperties.STATUS, 2, 1, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.NONE, [], [{
+        "value": 1,
+        "description": "Sweeping"
+      },
+      {
+        "value": 2,
+        "description": "Idle"
+      },
+      {
+        "value": 3,
+        "description": "Paused"
+      },
+      {
+        "value": 4,
+        "description": "Error"
+      },
+      {
+        "value": 5,
+        "description": "Go Charging"
+      },
+      {
+        "value": 6,
+        "description": "Charging"
+      },
+      {
+        "value": 7,
+        "description": "Mopping"
+      }
+    ]);
+    this.addProperty(RobotCleanerProperties.DEVICE_FAULT, 2, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.NONE, [], [{
+      "value": 0,
+      "description": "No Faults"
+    }]);
+    this.addProperty(RobotCleanerProperties.BATTERY_LEVEL, 3, 1, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.PERCENTAGE, [0, 100, 1]);
+    this.addProperty(RobotCleanerProperties.CHARGING_STATE, 3, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.NONE, [], [{
+        "value": 1,
+        "description": "Charging"
+      },
+      {
+        "value": 2,
+        "description": "Not Charging"
+      },
+      {
+        "value": 5,
+        "description": "Go Charging"
+      }
+    ]);
+    this.addProperty(RobotCleanerProperties.BRUSH_LEFT_TIME, 9, 1, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.HOURS, [0, 300, 1]);
+    this.addProperty(RobotCleanerProperties.BRUSH_LIFE_LEVEL, 9, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.PERCENTAGE, [0, 100, 1]);
+    this.addProperty(RobotCleanerProperties.SIDE_BRUSH_LEFT_TIME, 10, 1, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.HOURS, [0, 200, 1]);
+    this.addProperty(RobotCleanerProperties.SIDE_BRUSH_LIFE_LEVEL, 10, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.PERCENTAGE, [0, 100, 1]);
+    this.addProperty(RobotCleanerProperties.FILTER_LIFE_LEVEL, 11, 1, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.PERCENTAGE, [0, 100, 1]);
+    this.addProperty(RobotCleanerProperties.FILTER_LEFT_TIME, 11, 2, PropFormat.UINT8, PropAccess.READ_NOTIFY, PropUnit.HOURS, [0, 150, 1]);
+    this.addProperty(RobotCleanerProperties.WORK_MODE, 4, 1, PropFormat.INT32, PropAccess.READ_NOTIFY, PropUnit.HOURS, [0, 50, 1]);
+    this.addProperty(RobotCleanerProperties.CLEANING_TIME, 4, 2, PropFormat.INT32, PropAccess.READ_NOTIFY, PropUnit.MINUTES, [0, 32767, 1]);
+    this.addProperty(RobotCleanerProperties.CLEANING_AREA, 4, 3, PropFormat.INT32, PropAccess.READ_NOTIFY, PropUnit.NONE, [0, 32767, 1]);
+    this.addProperty(RobotCleanerProperties.TOTAL_CLEAN_TIME, 12, 2, PropFormat.UINT32, PropAccess.READ_NOTIFY, PropUnit.MINUTES, [0, 4294967295, 1]);
+    this.addProperty(RobotCleanerProperties.TOTAL_CLEAN_TIMES, 12, 3, PropFormat.UINT32, PropAccess.READ_NOTIFY, PropUnit.NONE, [0, 4294967295, 1]);
+    this.addProperty(RobotCleanerProperties.TOTAL_CLEAN_AREA, 12, 4, PropFormat.UINT32, PropAccess.READ_NOTIFY, PropUnit.NONE, [0, 4294967295, 1]);
+  }
+
+  initDeviceActions() {
+    this.addAction(RobotCleanerActions.START_SWEEP, 2, 1, []);
+    this.addAction(RobotCleanerActions.STOP_SWEEP, 2, 2, []);
+    this.addAction(RobotCleanerActions.START_CHARGE, 3, 1, []);
+    this.addAction(RobotCleanerActions.RESET_BRUSH_LIFE, 9, 1, []);
+    this.addAction(RobotCleanerActions.RESET_SIDE_BRUSH_LIFE, 10, 1, []);
+    this.addAction(RobotCleanerActions.RESET_FILTER_LIFE, 11, 1, []);
+    this.addAction(RobotCleanerActions.START_CLEAN, 4, 1, [10]);
+    this.addAction(RobotCleanerActions.ROOM_CLEAN, 4, 1, [1, 10]);
+    this.addAction(RobotCleanerActions.STOP_CLEAN, 4, 2, []);
+    this.addAction(RobotCleanerActions.LOCATE_ROBOT, 7, 1, []);
+    this.addAction(RobotCleanerActions.PLAY_SOUND, 7, 2, []);
+  }
+
+
+  /*----------========== CONFIG ==========----------*/
+
+  hasBuiltInBattery() {
+    return true;
+  }
+
+  statusSweepingValue() {
+    return 1;
+  }
+
+  statusIdleValue() {
+    return 2;
+  }
+
+  statusPausedValue() {
+    return 3;
+  }
+
+  statusErrorValue() {
+    return 4;
+  }
+
+  statusGoChargingValue() {
+    return 5;
+  }
+
+  statusChargingValue() {
+    return 6;
+  }
+
+  chargingStateChargingValue() {
+    return 1;
+  }
+
+  chargingStateNotChargingValue() {
+    return 2;
+  }
+
+  chargingStateGoChargingValue() {
+    return 3;
+  }
+
+
+}
+
+module.exports = DreameVacuumP2041;

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -68,6 +68,7 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 * dreame.vacuum.p2008 (Dreame F9)
 * dreame.vacuum.p2009 (Dreame D9)
 * dreame.vacuum.mc1808 (Xiaomi Mijia 1C Sweeping Vacuum Cleaner)
+* dreame.vacuum.p2041 (Xiaomi Mijia 1T Robot Vacuum Cleaner)
 * roborock.vacuum.a15 (Roborock Vacuum S7)
 * roborock.vacuum.a11 (Roborock Vacuum T7)
 * roborock.vacuum.m1s (Xiaomi Mi Robot 1S) 🔵[MiCloud]


### PR DESCRIPTION
I just got this robot. The miot command set is almost identical to dreame.vacuum.p2008. Everything seems to work.

I also wanted room cleaning functionality. I have added a room_clean action for the vacuum which calls the cleaning command with the appropriate parameters to initiate targeted cleaning. The custom action definition for room cleaning in the homebridge config has to be something like:

{
    "action": "room_clean",
    "name": "Clean Kitchen",
    "params": [
        18,
        "{\"selects\": [[4,1,1,2,1]]}"
    ]
}

The first parameter of 18 is passed to piid 1 and indicates room cleaning (19 would be area cleaning).
The value in the double square brackets, passed to piid 10,  is then:
[[room_id, number of cleaning repetitions, vacuum power, mopping water flow, index]]
I believe multiple rooms to be cleaned can also be selected. 
I got this command format from the discussion here: https://github.com/rytilahti/python-miio/issues/870#issue-751099906 

In my case the room IDs were simply 1,2,3,4 and I figured out which room they correspond to manually. 