### PR TITLE
Adding support for Xiaomi PM 2.5 Monitor  (zhimi.airmonitor.v1)

### DIFF
--- a/lib/modules/airmonitor/devices/zhimi.airmonitor.v1.js
+++ b/lib/modules/airmonitor/devices/zhimi.airmonitor.v1.js
@@ -1,0 +1,79 @@
+const AirMonitorDevice = require('../AirMonitorDevice.js');
+const Constants = require('../../../constants/Constants.js');
+const PropFormat = require('../../../constants/PropFormat.js');
+const PropUnit = require('../../../constants/PropUnit.js');
+const PropAccess = require('../../../constants/PropAccess.js');
+
+class ZhimiAirmonitorV1 extends AirMonitorDevice {
+  constructor(miotDevice, name, logger) {
+    super(miotDevice, name, logger);
+  }
+
+
+  /*----------========== DEVICE INFO ==========----------*/
+
+  getDeviceName() {
+    return 'Xiaomi PM 2.5 Monitor';
+  }
+
+  getMiotSpecUrl() {
+    return 'https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-monitor:0000A008:zhimi-v1:1';
+  }
+
+
+  /*----------========== CONFIG ==========----------*/
+
+  requiresMiCloud() {
+    return false;
+  }
+
+  propertiesToMonitor() {
+    return [];
+  }
+
+
+  /*----------========== METADATA ==========----------*/
+
+  initDeviceServices() {
+    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:device:air-monitor:0000A008:zhimi-v1:1","description":"Environment"}');
+    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:battery:00007805:zhimi-v1:","description":"Battery"}');
+  }
+
+  initDeviceProperties() {
+    this.addPropertyByString('environment:pm2.5-density', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:pm2.5-density:00000034:zhimi-v1:1","description":"PM2.5 Density","format":"float","access":["read","notify"],"valueRange":[0,600,1]}');
+    this.addPropertyByString('battery:battery-level', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:battery-level:00000014:zhimi-v1:1","description":"Battery Level","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
+    this.addPropertyByString('battery:charging-state', '{"siid":3,"piid":2,"type":"urn:miot-spec-v2:property:charging-state:00000015:zhimi-v1:1","description":"Charging State","format":"uint8","access":["read","notify"],"valueList":[{"value":1,"description":"Charging"},{"value":2,"description":"Not charging"}]}');
+  }
+
+  initDeviceActions() {
+   //no actions
+  }
+
+  initDeviceEvents() {
+    //no events
+  }
+
+
+  /*----------========== VALUES OVERRIDES ==========----------*/
+
+  chargingStateChargingValue() {
+    return 1;
+  }
+
+  chargingStateNotChargingValue() {
+    return 2;
+  }
+
+
+  /*----------========== PROPERTY OVERRIDES ==========----------*/
+
+
+  /*----------========== ACTION OVERRIDES ==========----------*/
+
+
+  /*----------========== OVERRIDES ==========----------*/
+
+
+}
+
+module.exports = ZhimiAirmonitorV1;

--- a/lib/modules/airmonitor/devices/zhimi.airmonitor.v1.js
+++ b/lib/modules/airmonitor/devices/zhimi.airmonitor.v1.js
@@ -4,6 +4,7 @@ const PropFormat = require('../../../constants/PropFormat.js');
 const PropUnit = require('../../../constants/PropUnit.js');
 const PropAccess = require('../../../constants/PropAccess.js');
 
+
 class ZhimiAirmonitorV1 extends AirMonitorDevice {
   constructor(miotDevice, name, logger) {
     super(miotDevice, name, logger);
@@ -24,7 +25,7 @@ class ZhimiAirmonitorV1 extends AirMonitorDevice {
   /*----------========== CONFIG ==========----------*/
 
   requiresMiCloud() {
-    return false;
+    return true;
   }
 
   propertiesToMonitor() {
@@ -35,7 +36,7 @@ class ZhimiAirmonitorV1 extends AirMonitorDevice {
   /*----------========== METADATA ==========----------*/
 
   initDeviceServices() {
-    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:device:air-monitor:0000A008:zhimi-v1:1","description":"Environment"}');
+    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:environment:0000780A:zhimi-v1:1","description":"Environment"}');
     this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:battery:00007805:zhimi-v1:","description":"Battery"}');
   }
 

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -211,4 +211,4 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 
 - cgllc.airmonitor.b1 (Xiaomi Air Quality Monitor) 🔵[MiCloud]
 - cgllc.airm.cgdn1 (Qingping Air Monitor Lite)
-- zhimi.airmonitor.v1 (Xiaomi PM2.5 Monitor)
+- zhimi.airmonitor.v1 (Xiaomi PM2.5 Monitor) 🔵[MiCloud]

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -209,5 +209,6 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 
 ### Air Monitor
 
--   cgllc.airmonitor.b1 (Xiaomi Air Quality Monitor) 🔵[MiCloud]
--   cgllc.airm.cgdn1 (Qingping Air Monitor Lite)
+- cgllc.airmonitor.b1 (Xiaomi Air Quality Monitor) 🔵[MiCloud]
+- cgllc.airm.cgdn1 (Qingping Air Monitor Lite)
+- zhimi.airmonitor.v1 (Xiaomi PM2.5 Monitor)


### PR DESCRIPTION
Hi @merdok 
I based on our design I have added support for Xiaomi PM 2.5 Monitor  (zhimi.airmonitor.v1). I thought it could work without Mi Cloud connection but unfortunately it can not.

I have it running for couple hours and everything seems to be ok.
Kindly accept my PR

