### PR TITLE
Update README.md with proper key word for platform name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Other ways:
 Keep in mind that your device needs to support the feature which you enable, otherwise you will not see any effect.
 #### Platform configuration fields
 - `platform` [required]
-Should always be **"miot"**.
+Must always be **"miot"**.
 - `devices` [required]
 A list of your devices.
 - `micloud` [optional]


### PR DESCRIPTION
Unless I am mistaken there is no optionality in platform name here.

Wording as defined by RFC https://www.ietf.org/rfc/rfc2119.txt