### PR TITLE
retry on error code -30001 and -9999

### DIFF
--- a/lib/protocol/MiioProtocol.js
+++ b/lib/protocol/MiioProtocol.js
@@ -6,6 +6,7 @@ const PORT = 54321;
 const HANDSHAKE_TIMEOUT = 5000;
 const DEFAULT_TIMEOUT = 4000;
 const DEFAULT_RETRIES = 2;
+const RECOVERABLE_ERRORS = [-30001, -9999];
 
 class MiioProtocol extends EventEmitter {
   constructor(logger) {
@@ -348,7 +349,6 @@ class MiioProtocol extends EventEmitter {
           resolve(res);
         },
         reject: err => {
-          resolved = true;
           device._promises.delete(request.id);
 
           if (!(err instanceof Error) && typeof err.code !== 'undefined') {
@@ -359,7 +359,15 @@ class MiioProtocol extends EventEmitter {
             err = new Error(message);
             err.code = code;
           }
+
+          if (RECOVERABLE_ERRORS.includes(err.code)) {
+            this.logger.deepDebug(`(Protocol) ${address} <- Receving recoverable error: (${err.code}) ${err.message}, retries left: ${retriesLeft}`);
+            retry();
+            return false;
+          }
+          
           this.logger.deepDebug(`(Protocol) ${address} <- Error during send! (${err.code}) ${err.message} | Request: ${JSON.stringify(request)}`);
+          resolved = true;
           reject(err);
         },
       };


### PR DESCRIPTION
Fixes #355 
Accroding to https://github.com/rytilahti/python-miio/blob/aa2718853455c40b5b8c2a1883019d8cb7a683b4/miio/miioprotocol.py#L272 and https://github.com/rytilahti/python-miio/pull/1363 
Some error code is recoverable.

Reproduced and fixed on mesh device `090615.switch.mesw2` with gateway `xiaomi.wifispeaker.lx06`, using:
```shell
miot send $GATEWAY_IP --token $GATEWAY_TOKEN --debug set_properties "[{\"did\":\"$DEVICE_ID\",\"value\":false,\"siid\":2,\"piid\":1}]" \
&& miot send $GATEWAY_IP --token $GATEWAY_TOKEN --debug set_properties "[{\"did\":\"$DEVICE_ID\",\"value\":false,\"siid\":2,\"piid\":1}]" \
&& miot send $GATEWAY_IP --token $GATEWAY_TOKEN --debug set_properties "[{\"did\":\"$DEVICE_ID\",\"value\":false,\"siid\":2,\"piid\":1}]" \
&& miot send $GATEWAY_IP --token $GATEWAY_TOKEN --debug set_properties "[{\"did\":\"$DEVICE_ID\",\"value\":false,\"siid\":2,\"piid\":1}]"
```

Default retries 1 is enough for processing error code -9999 in my test.