### PR TITLE
Add support for zhimi.airpurifier.v3

### DIFF
--- a/lib/modules/airpurifier/devices/zhimi.airpurifier.v3.js
+++ b/lib/modules/airpurifier/devices/zhimi.airpurifier.v3.js
@@ -1,0 +1,98 @@
+const AirPurifierDevice = require('../AirPurifierDevice.js');
+const Constants = require('../../../constants/Constants.js');
+const PropFormat = require('../../../constants/PropFormat.js');
+const PropUnit = require('../../../constants/PropUnit.js');
+const PropAccess = require('../../../constants/PropAccess.js');
+
+
+class ZhimiAirpurifierV6 extends AirPurifierDevice {
+  constructor(miotDevice, name, logger) {
+    super(miotDevice, name, logger);
+  }
+
+
+  /*----------========== DEVICE INFO ==========----------*/
+
+  getDeviceName() {
+    return 'Xiaomi Mi Air Purifier Pro V6';
+  }
+
+  getMiotSpecUrl() {
+    return 'https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-v6:1';
+  }
+
+
+  /*----------========== CONFIG ==========----------*/
+
+  requiresMiCloud() {
+    return true;
+  }
+
+
+  /*----------========== METADATA ==========----------*/
+
+  initDeviceServices() {
+    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:air-purifier:00007811:zhimi-v6:1","description":"Air Purifier"}');
+    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:environment:0000780A:zhimi-v6:1","description":"Environment"}');
+    this.createServiceByString('{"siid":4,"type":"urn:miot-spec-v2:service:filter:0000780B:zhimi-v6:1","description":"Filter"}');
+    this.createServiceByString('{"siid":5,"type":"urn:miot-spec-v2:service:indicator-light:00007803:zhimi-v6:1","description":"Indicator Light"}');
+    this.createServiceByString('{"siid":6,"type":"urn:miot-spec-v2:service:alarm:00007804:zhimi-v6:1","description":"Alarm"}');
+    this.createServiceByString('{"siid":7,"type":"urn:miot-spec-v2:service:physical-controls-locked:00007807:zhimi-v6:1","description":"Physical Control Locked"}');
+    this.createServiceByString('{"siid":8,"type":"urn:miot-spec-v2:service:air-purifier-favorite:000078B2:zhimi-v6:1","description":"Air Purifier Favorite"}');
+  }
+
+  initDeviceProperties() {
+    this.addPropertyByString('air-purifier:on', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v6:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('air-purifier:fan-level', '{"siid":2,"piid":2,"type":"urn:miot-spec-v2:property:fan-level:00000016:zhimi-v6:1","description":"Fan Level","format":"uint8","access":["read","write","notify"],"valueList":[{"value":0,"description":"Auto"},{"value":1,"description":"Sleep"},{"value":2,"description":"Favorite"}]}');
+    this.addPropertyByString('air-purifier:mode', '{"siid":2,"piid":3,"type":"urn:miot-spec-v2:property:mode:00000008:zhimi-v6:1","description":"Mode","format":"uint8","access":["read","write"],"valueList":[{"value":0,"description":"Auto"},{"value":1,"description":"Sleep"},{"value":2,"description":"Favorite"}]}');
+    this.addPropertyByString('environment:relative-humidity', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:relative-humidity:0000000C:zhimi-v6:1","description":"Relative Humidity","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
+    this.addPropertyByString('environment:pm2.5-density', '{"siid":3,"piid":2,"type":"urn:miot-spec-v2:property:pm2.5-density:00000034:zhimi-v6:1","description":"PM2.5 Density","format":"float","access":["read","notify"],"valueRange":[0,600,1]}');
+    this.addPropertyByString('environment:temperature', '{"siid":3,"piid":3,"type":"urn:miot-spec-v2:property:temperature:00000020:zhimi-v6:1","description":"Indoor Temperature","format":"float","access":["read","notify"],"unit":"celsius","valueRange":[-40,125,0.1]}');
+    this.addPropertyByString('filter:filter-life-level', '{"siid":4,"piid":1,"type":"urn:miot-spec-v2:property:filter-life-level:0000001E:zhimi-v6:1","description":"Filter Life Level","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
+    this.addPropertyByString('filter:filter-used-time', '{"siid":4,"piid":2,"type":"urn:miot-spec-v2:property:filter-used-time:00000048:zhimi-v6:1","description":"Filter Used Time","format":"uint16","access":["read","notify"],"unit":"hours","valueRange":[0,10000,1]}');
+    this.addPropertyByString('indicator-light:on', '{"siid":5,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v6:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('alarm:alarm', '{"siid":6,"piid":1,"type":"urn:miot-spec-v2:property:alarm:00000012:zhimi-v6:1","description":"Alarm","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('physical-controls-locked:physical-controls-locked', '{"siid":7,"piid":1,"type":"urn:miot-spec-v2:property:physical-controls-locked:0000001D:zhimi-v6:1","description":"Physical Control Locked","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('air-purifier-favorite:favorite-fan-level', '{"siid":8,"piid":1,"type":"urn:miot-spec-v2:property:favorite-fan-level:00000123:zhimi-v6:1","description":"Favorite Fan Level","format":"uint8","access":["read","write","notify"],"valueRange":[0,16,1]}');
+  }
+
+  initDeviceActions() {
+    //no actions
+  }
+
+  initDeviceEvents() {
+    //no events
+  }
+
+
+  /*----------========== VALUES OVERRIDES ==========----------*/
+
+  autoModeValue() {
+    return 0;
+  }
+
+  sleepModeValue() {
+    return 1;
+  }
+
+  favoriteModeValue() {
+    return 2;
+  }
+
+
+  /*----------========== PROPERTY OVERRIDES ==========----------*/
+
+  favoriteLevelProp() {
+    return this.getProperty('air-purifier-favorite:favorite-fan-level');
+  }
+
+
+  /*----------========== ACTION OVERRIDES ==========----------*/
+
+
+  /*----------========== OVERRIDES ==========----------*/
+
+
+}
+
+module.exports = ZhimiAirpurifierV6;

--- a/lib/modules/airpurifier/devices/zhimi.airpurifier.v3.js
+++ b/lib/modules/airpurifier/devices/zhimi.airpurifier.v3.js
@@ -5,7 +5,7 @@ const PropUnit = require('../../../constants/PropUnit.js');
 const PropAccess = require('../../../constants/PropAccess.js');
 
 
-class ZhimiAirpurifierV6 extends AirPurifierDevice {
+class ZhimiAirpurifierV3 extends AirPurifierDevice {
   constructor(miotDevice, name, logger) {
     super(miotDevice, name, logger);
   }
@@ -14,11 +14,11 @@ class ZhimiAirpurifierV6 extends AirPurifierDevice {
   /*----------========== DEVICE INFO ==========----------*/
 
   getDeviceName() {
-    return 'Xiaomi Mi Air Purifier Pro V6';
+    return 'Xiaomi Mi Air Purifier';
   }
 
   getMiotSpecUrl() {
-    return 'https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-v6:1';
+    return 'https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-v3:1';
   }
 
 
@@ -32,32 +32,28 @@ class ZhimiAirpurifierV6 extends AirPurifierDevice {
   /*----------========== METADATA ==========----------*/
 
   initDeviceServices() {
-    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:air-purifier:00007811:zhimi-v6:1","description":"Air Purifier"}');
-    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:environment:0000780A:zhimi-v6:1","description":"Environment"}');
-    this.createServiceByString('{"siid":4,"type":"urn:miot-spec-v2:service:filter:0000780B:zhimi-v6:1","description":"Filter"}');
-    this.createServiceByString('{"siid":5,"type":"urn:miot-spec-v2:service:indicator-light:00007803:zhimi-v6:1","description":"Indicator Light"}');
-    this.createServiceByString('{"siid":6,"type":"urn:miot-spec-v2:service:alarm:00007804:zhimi-v6:1","description":"Alarm"}');
-    this.createServiceByString('{"siid":7,"type":"urn:miot-spec-v2:service:physical-controls-locked:00007807:zhimi-v6:1","description":"Physical Control Locked"}');
-    this.createServiceByString('{"siid":8,"type":"urn:miot-spec-v2:service:air-purifier-favorite:000078B2:zhimi-v6:1","description":"Air Purifier Favorite"}');
+    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:air-purifier:00007811:zhimi-v3:1","description":"Air Purifier"}');
+    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:environment:0000780A:zhimi-v3:1","description":"Environment"}');
+    this.createServiceByString('{"siid":4,"type":"urn:miot-spec-v2:service:filter:0000780B:zhimi-v3:1","description":"Filter"}');
+    this.createServiceByString('{"siid":5,"type":"urn:miot-spec-v2:service:indicator-light:00007803:zhimi-v3:1","description":"Indicator Light"}');
+    this.createServiceByString('{"siid":6,"type":"urn:miot-spec-v2:service:alarm:00007804:zhimi-v3:1","description":"Alarm"}');
+    this.createServiceByString('{"siid":7,"type":"urn:miot-spec-v2:service:physical-controls-locked:00007807:zhimi-v3:1","description":"Physical Control Locked"}');
   }
 
   initDeviceProperties() {
-    this.addPropertyByString('air-purifier:on', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v6:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
-    this.addPropertyByString('air-purifier:fan-level', '{"siid":2,"piid":2,"type":"urn:miot-spec-v2:property:fan-level:00000016:zhimi-v6:1","description":"Fan Level","format":"uint8","access":["read","write","notify"],"valueList":[{"value":0,"description":"Auto"},{"value":1,"description":"Sleep"},{"value":2,"description":"Favorite"}]}');
-    this.addPropertyByString('air-purifier:mode', '{"siid":2,"piid":3,"type":"urn:miot-spec-v2:property:mode:00000008:zhimi-v6:1","description":"Mode","format":"uint8","access":["read","write"],"valueList":[{"value":0,"description":"Auto"},{"value":1,"description":"Sleep"},{"value":2,"description":"Favorite"}]}');
-    this.addPropertyByString('environment:relative-humidity', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:relative-humidity:0000000C:zhimi-v6:1","description":"Relative Humidity","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
-    this.addPropertyByString('environment:pm2.5-density', '{"siid":3,"piid":2,"type":"urn:miot-spec-v2:property:pm2.5-density:00000034:zhimi-v6:1","description":"PM2.5 Density","format":"float","access":["read","notify"],"valueRange":[0,600,1]}');
-    this.addPropertyByString('environment:temperature', '{"siid":3,"piid":3,"type":"urn:miot-spec-v2:property:temperature:00000020:zhimi-v6:1","description":"Indoor Temperature","format":"float","access":["read","notify"],"unit":"celsius","valueRange":[-40,125,0.1]}');
-    this.addPropertyByString('filter:filter-life-level', '{"siid":4,"piid":1,"type":"urn:miot-spec-v2:property:filter-life-level:0000001E:zhimi-v6:1","description":"Filter Life Level","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
-    this.addPropertyByString('filter:filter-used-time', '{"siid":4,"piid":2,"type":"urn:miot-spec-v2:property:filter-used-time:00000048:zhimi-v6:1","description":"Filter Used Time","format":"uint16","access":["read","notify"],"unit":"hours","valueRange":[0,10000,1]}');
-    this.addPropertyByString('indicator-light:on', '{"siid":5,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v6:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
-    this.addPropertyByString('alarm:alarm', '{"siid":6,"piid":1,"type":"urn:miot-spec-v2:property:alarm:00000012:zhimi-v6:1","description":"Alarm","format":"bool","access":["read","write","notify"]}');
-    this.addPropertyByString('physical-controls-locked:physical-controls-locked', '{"siid":7,"piid":1,"type":"urn:miot-spec-v2:property:physical-controls-locked:0000001D:zhimi-v6:1","description":"Physical Control Locked","format":"bool","access":["read","write","notify"]}');
-    this.addPropertyByString('air-purifier-favorite:favorite-fan-level', '{"siid":8,"piid":1,"type":"urn:miot-spec-v2:property:favorite-fan-level:00000123:zhimi-v6:1","description":"Favorite Fan Level","format":"uint8","access":["read","write","notify"],"valueRange":[0,16,1]}');
+    this.addPropertyByString('air-purifier:on', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v3:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('air-purifier:fan-level', '{"siid":2,"piid":2,"type":"urn:miot-spec-v2:property:fan-level:00000016:zhimi-v3:1","description":"Fan Level","format":"uint8","access":["read","write","notify"],"valueList":[{"value":1,"description":"Low"},{"value":2,"description":"Medium"},{"value":3,"description":"High"}]}');
+    this.addPropertyByString('air-purifier:mode', '{"siid":2,"piid":3,"type":"urn:miot-spec-v2:property:mode:00000008:zhimi-v3:1","description":"Mode","format":"uint8","access":["read","write","notify"],"valueList":[{"value":0,"description":"Auto"},{"value":1,"description":"Sleep"},{"value":2,"description":"Strong"},{"value":3,"description":"None"}]}');
+    this.addPropertyByString('environment:pm2.5-density', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:pm2.5-density:00000034:zhimi-v3:1","description":"PM2.5 Density","format":"float","access":["read","notify"],"valueRange":[0,600,1]}');
+    this.addPropertyByString('filter:filter-life-level', '{"siid":4,"piid":1,"type":"urn:miot-spec-v2:property:filter-life-level:0000001E:zhimi-v3:1","description":"Filter Life Level","format":"uint8","access":["read","notify"],"unit":"percentage","valueRange":[0,100,1]}');
+    this.addPropertyByString('filter:filter-left-time', '{"siid":4,"piid":2,"type":"urn:miot-spec-v2:property:filter-left-time:0000001F:zhimi-v3:1","description":"Filter Left Time","format":"uint16","access":["read"],"unit":"hours"}');
+    this.addPropertyByString('indicator-light:on', '{"siid":5,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:zhimi-v3:1","description":"Indicator Light Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('alarm:alarm', '{"siid":6,"piid":1,"type":"urn:miot-spec-v2:property:alarm:00000012:zhimi-v3:1","description":"Alarm","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('physical-controls-locked:physical-controls-locked', '{"siid":7,"piid":1,"type":"urn:miot-spec-v2:property:physical-controls-locked:0000001D:zhimi-v3:1","description":"Physical Control Locked","format":"bool","access":["read","write","notify"]}');
   }
 
   initDeviceActions() {
-    //no actions
+    this.addActionByString('filter:reset-filter-life', '{"siid":4,"aiid":1,"type":"urn:miot-spec-v2:action:reset-filter-life:00002803:zhimi-v3:1","description":"Reset Filter Life","in":[],"out":[]}');
   }
 
   initDeviceEvents() {
@@ -75,16 +71,12 @@ class ZhimiAirpurifierV6 extends AirPurifierDevice {
     return 1;
   }
 
-  favoriteModeValue() {
-    return 2;
+  manualModeValue() {
+    return 3;
   }
 
 
   /*----------========== PROPERTY OVERRIDES ==========----------*/
-
-  favoriteLevelProp() {
-    return this.getProperty('air-purifier-favorite:favorite-fan-level');
-  }
 
 
   /*----------========== ACTION OVERRIDES ==========----------*/
@@ -95,4 +87,4 @@ class ZhimiAirpurifierV6 extends AirPurifierDevice {
 
 }
 
-module.exports = ZhimiAirpurifierV6;
+module.exports = ZhimiAirpurifierV3;

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -69,6 +69,7 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 -   zhimi.airpurifier.za1 (Smartmi Air Purifier)
 -   zhimi.airpurifier.mc2 (Xiaomi Air Purifier 2H) 🔵[MiCloud]
 -   zhimi.airpurifier.ma2 (Xiaomi Air Purifier 2S) 🔵[MiCloud]
+-   zhimi.airpurifier.v3 (Xiaomi Mi Air Purifier) 🔵[MiCloud]
 -   zhimi.airpurifier.v6 (Xiaomi Mi Air Purifier Pro V6) 🔵[MiCloud]
 -   zhimi.airpurifier.v7 (Xiaomi Mi Air Purifier Pro V7) 🔵[MiCloud]
 -   zhimi.airpurifier.xa1 (Mi Air Purifier X)


### PR DESCRIPTION
PS: The `zhimi.airpurifier.v3` product name is not v3, it's just first version of Xiaomi Mi Air Purifier.

However there's a known issue for this device: fan level polling failed. If anyone knows how to solve it, please have a try.
`Error while parsing response from device for property air-purifier:fan-level. Response: {"did":"686324","siid":2,"piid":2,"code":-704220043,"exe_time":0}`
