### PR TITLE
added support for the Viomi Kick-Line heater Pro2

### DIFF
--- a/lib/modules/heater/HeaterAccessory.js
+++ b/lib/modules/heater/HeaterAccessory.js
@@ -221,7 +221,6 @@ class HeaterAccessory extends GenericAccessory {
     if (this.getDevice().supportsTargetTemperature()) {
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.CurrentHeaterCoolerState).updateValue(this.getCurrentHeaterCoolerState());
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.TargetHeaterCoolerState).updateValue(this.getTargetHeaterCoolerState());
-      if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(this.getCurrentTemperature());
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.HeatingThresholdTemperature).updateValue(this.getHeatingThresholdTemperature());
     }
 

--- a/lib/modules/heater/HeaterAccessory.js
+++ b/lib/modules/heater/HeaterAccessory.js
@@ -221,6 +221,7 @@ class HeaterAccessory extends GenericAccessory {
     if (this.getDevice().supportsTargetTemperature()) {
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.CurrentHeaterCoolerState).updateValue(this.getCurrentHeaterCoolerState());
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.TargetHeaterCoolerState).updateValue(this.getTargetHeaterCoolerState());
+      if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(this.getCurrentTemperature());
       if (this.heaterService) this.heaterService.getCharacteristic(Characteristic.HeatingThresholdTemperature).updateValue(this.getHeatingThresholdTemperature());
     }
 

--- a/lib/modules/heater/HeaterDevice.js
+++ b/lib/modules/heater/HeaterDevice.js
@@ -33,7 +33,7 @@ class HeaterDevice extends GenericDevice {
   /*----------========== CONFIG ==========----------*/
 
   propertiesToMonitor() {
-    return ['heater:on', 'heater:mode', 'heater:fault', 'heater:target-temperature',
+    return ['heater:on', 'heater:mode', 'heater:fault', 'heater:target-temperature', 'heater:temperature', 
       'countdown:countdown-time', 'private-service:use-time', 'heater:heat-level', 'electric-blanket:on',
       'electric-blanket:fault', 'electric-blanket:mode', 'electric-blanket:target-temperature', 'electric-blanket:temperature',
       'electric-blanket:water-level'

--- a/lib/modules/heater/devices/viomi.heater.v4.js
+++ b/lib/modules/heater/devices/viomi.heater.v4.js
@@ -1,0 +1,83 @@
+const HeaterDevice = require('../HeaterDevice.js');
+const Constants = require('../../../constants/Constants.js');
+const PropFormat = require('../../../constants/PropFormat.js');
+const PropUnit = require('../../../constants/PropUnit.js');
+const PropAccess = require('../../../constants/PropAccess.js');
+
+
+class ViomiHeaterV4 extends HeaterDevice {
+  constructor(miotDevice, name, logger) {
+    super(miotDevice, name, logger);
+  }
+
+
+  /*----------========== DEVICE INFO ==========----------*/
+
+  getDeviceName() {
+    return 'Viomi Kick-Line heater Pro2';
+  }
+
+  getMiotSpecUrl() {
+    return 'https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:heater:0000A01A:viomi-v4:1';
+  }
+
+
+  /*----------========== CONFIG ==========----------*/
+
+  requiresMiCloud() {
+    return true;
+  }
+
+
+  /*----------========== METADATA ==========----------*/
+
+  initDeviceServices() {
+    this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:heater:0000782E:viomi-v4:1","description":"Heater"}');
+    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:countdown:0000782D:viomi-v4:1","description":"Countdown"}');
+    this.createServiceByString('{"siid":4,"type":"urn:miot-spec-v2:service:humidifier:00007818:viomi-v4:1","description":"Humidifier"}');
+    this.createServiceByString('{"siid":5,"type":"urn:miot-spec-v2:service:screen:00007806:viomi-v4:1","description":"Screen"}');
+    this.createServiceByString('{"siid":6,"type":"urn:miot-spec-v2:service:alarm:00007804:viomi-v4:1","description":"Alarm"}');
+  }
+
+  initDeviceProperties() {
+    this.addPropertyByString('heater:on', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:viomi-v4:1","description":"Switch Status","format":"bool","access":["read","write","notify"],"unit":"none"}');
+    this.addPropertyByString('heater:fault', '{"siid":2,"piid":2,"type":"urn:miot-spec-v2:property:fault:00000009:viomi-v4:1","description":"Device Fault","format":"uint8","access":["read","notify"],"unit":"none","valueList":[{"value":0,"description":"NO"},{"value":1,"description":"E"},{"value":2,"description":"E"},{"value":3,"description":"E"}]}');
+    this.addPropertyByString('heater:status', '{"siid":2,"piid":3,"type":"urn:miot-spec-v2:property:status:00000007:viomi-v4:1","description":"Status","format":"uint8","access":["read","notify"],"unit":"none","valueList":[{"value":0,"description":"Idle"},{"value":1,"description":"Busy"},{"value":2,"description":"Appointment"}]}');
+    this.addPropertyByString('heater:mode', '{"siid":2,"piid":4,"type":"urn:miot-spec-v2:property:mode:00000008:viomi-v4:1","description":"Mode","format":"uint8","access":["read","write","notify"],"unit":"none","valueList":[{"value":1,"description":"Auto"},{"value":2,"description":"Strong"}]}');
+    this.addPropertyByString('heater:target-temperature', '{"siid":2,"piid":5,"type":"urn:miot-spec-v2:property:target-temperature:00000021:viomi-v4:1","description":"Target Temperature","format":"uint16","access":["read","write","notify"],"unit":"celsius","valueRange":[5,35,1]}');
+    this.addPropertyByString('heater:temperature', '{"siid":2,"piid":7,"type":"urn:miot-spec-v2:property:temperature:00000020:viomi-v4:1","description":"Temperature","format":"float","access":["read","notify"],"unit":"celsius","valueRange":[-30,100,1]}');
+    this.addPropertyByString('heater:working-time', '{"siid":2,"piid":8,"type":"urn:miot-spec-v2:property:working-time:00000079:viomi-v4:1","description":"Working Time","format":"uint32","access":["read","notify"],"unit":"minutes","valueRange":[0,99999999,1]}');
+    this.addPropertyByString('countdown:countdown-time', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:countdown-time:00000055:viomi-v4:1","description":"Countdown Time","format":"float","access":["read","write","notify"],"unit":"hours","valueRange":[0,24,0.5]}');
+    this.addPropertyByString('humidifier:on', '{"siid":4,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:viomi-v4:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('humidifier:fault', '{"siid":4,"piid":2,"type":"urn:miot-spec-v2:property:fault:00000009:viomi-v4:1","description":"Device Fault","format":"uint8","access":["read","notify"],"unit":"none","valueList":[{"value":0,"description":"No Faults"}]}');
+    this.addPropertyByString('screen:on', '{"siid":5,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:viomi-v4:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
+    this.addPropertyByString('alarm:alarm', '{"siid":6,"piid":1,"type":"urn:miot-spec-v2:property:alarm:00000012:viomi-v4:1","description":"Alarm","format":"bool","access":["read","write","notify"]}');
+  }
+
+  initDeviceActions() {
+   //no actions
+  }
+
+  initDeviceEvents() {
+    //no events
+  }
+
+
+  /*----------========== VALUES OVERRIDES ==========----------*/
+
+  temperatureProp() {
+    return this.getProperty('heater:temperature');
+  }
+
+  /*----------========== PROPERTY OVERRIDES ==========----------*/
+
+
+  /*----------========== ACTION OVERRIDES ==========----------*/
+
+
+  /*----------========== OVERRIDES ==========----------*/
+
+
+}
+
+module.exports = ViomiHeaterV4;

--- a/lib/modules/heater/devices/viomi.heater.v4.js
+++ b/lib/modules/heater/devices/viomi.heater.v4.js
@@ -65,12 +65,12 @@ class ViomiHeaterV4 extends HeaterDevice {
 
   /*----------========== VALUES OVERRIDES ==========----------*/
 
-  temperatureProp() {
-    return this.getProperty('heater:temperature');
-  }
 
   /*----------========== PROPERTY OVERRIDES ==========----------*/
 
+  temperatureProp() {
+    return this.getProperty('heater:temperature');
+  }
 
   /*----------========== ACTION OVERRIDES ==========----------*/
 

--- a/supported_devices.md
+++ b/supported_devices.md
@@ -45,6 +45,7 @@ Devices marked as 🔵[MiCloud] require a MiCloud connection. Please specify the
 -   leshow.heater.bs3 (Mi Smart Baseboard Heater 3)
 -   isleep.blanket.hs2205 (Painted sleep water heating pad HS2205)
 -   isleep.blanket.hs2201 (Painted sleep water heating pad HS2201)
+-   viomi.heater.v4 (Viomi Kick-Line heater Pro2) 🔵[MiCloud]
 
 ### Humidifier
 


### PR DESCRIPTION
Since some heaters (like the Viomi Kick-Line Heater) doesn't support environment:temperature properties, temperature readings on Apple Home when the device is turned on will be 0. These devices instead publish their temperature readings through heater:temperature property and this will need to be displayed instead.