### PR TITLE
Fix ColorTemperature handling (percentage → HomeKit mired)

### DIFF
--- a/lib/services/LightService.js
+++ b/lib/services/LightService.js
@@ -266,18 +266,42 @@ class LightService extends AbstractService {
   /*----------========== CONVENIENCE ==========----------*/
 
   getColorTempMired() {
-    let colorTempKelvin = this.getColorTemperature();
-    if (colorTempKelvin > 0) {
-      return Math.floor(1000000 / colorTempKelvin);
+    let ct = this.getColorTemperature();
+    let prop = this._colorTemperatureProp();
+
+    // % (1..100) -> mired (500..140)
+    if (prop && prop.getUnit && prop.getUnit() === PropUnit.PERCENTAGE) {
+      const pct = Math.max(1, Math.min(100, Number(ct) || 1));
+      const minMired = 140;
+      const maxMired = 500;
+
+      // 1 = warm (maxMired), 100 = cold (minMired)
+      const mired = maxMired - ((pct - 1) * (maxMired - minMired) / 99);
+      return Math.round(mired);
     }
+
+    // default (kelvin -> mired)
+    if (ct > 0) return Math.floor(1000000 / ct);
     return this.getMinColorTempValue();
   }
 
   async setColorTempMired(miredVal) {
+    let prop = this._colorTemperatureProp();
+
+    if (prop && prop.getUnit && prop.getUnit() === PropUnit.PERCENTAGE) {
+      const minMired = 140;
+      const maxMired = 500;
+      const m = Math.max(minMired, Math.min(maxMired, Number(miredVal) || maxMired));
+
+      // mired (500..140) -> % (1..100)
+      const pct = 1 + ((maxMired - m) * 99 / (maxMired - minMired));
+      return this.setColorTemperature(Math.round(pct));
+    }
+
+    // default (mired -> kelvin)
     if (miredVal > 0) {
-      let kelvinVal = 1000000 / miredVal;
-      kelvinVal = Math.floor(kelvinVal);
-      this.setColorTemperature(kelvinVal);
+      let kelvinVal = Math.floor(1000000 / miredVal);
+      return this.setColorTemperature(kelvinVal);
     }
   }
 
@@ -323,6 +347,8 @@ class LightService extends AbstractService {
 
   // color temp
   getMinColorTempValue() {
+    let prop = this._colorTemperatureProp();
+    if (prop && prop.getUnit && prop.getUnit() === PropUnit.PERCENTAGE) return 140; // HomeKit min
     let colorTempRange = this.getPropertyValueRange(this._colorTemperatureProp());
     let minVal = 140;
     if (colorTempRange && colorTempRange.length > 2) {
@@ -333,6 +359,8 @@ class LightService extends AbstractService {
   }
 
   getMaxColorTempValue() {
+    let prop = this._colorTemperatureProp();
+    if (prop && prop.getUnit && prop.getUnit() === PropUnit.PERCENTAGE) return 500; // HomeKit max
     let colorTempRange = this.getPropertyValueRange(this._colorTemperatureProp ());
     let maxVal = 500;
     if (colorTempRange && colorTempRange.length > 2) {


### PR DESCRIPTION
… HomeKit mired)

Problem

Device philips.light.candle2 exposes MIoT property light:color-temperature as percentage (1..100) (confirmed in logs: e.g. value: 14). homebridge-miot currently treats color-temperature as Kelvin and converts it to HomeKit using mired = 1_000_000 / kelvin. When applied to percentage values, this produces extremely large/invalid mired values (e.g. 1_000_000 / 14 = 71428), which causes HomeKit to show red/invalid color temperature control and leads to poor UX (frequent resync / laggy controls).

Changes
	•	Detect MIoT color-temperature properties that are declared as percentage (or have a 1..100 range).
	•	For percentage-based devices, map 1..100 ↔ HomeKit mired range (500..140) instead of Kelvin conversion:
	•	getColorTempMired: percentage → mired
	•	setColorTempMired: mired → percentage
	•	Adjust getMinColorTempValue / getMaxColorTempValue accordingly for percentage-based color temperature, so HomeKit receives valid min/max bounds.

Result
	•	HomeKit ColorTemperature slider is no longer shown in red for philips.light.candle2.
	•	Color temperature changes are applied consistently.
	•	Overall control responsiveness improves (no invalid CT updates causing repeated corrections).

Notes

This fix is backward compatible: Kelvin-based color temperature devices keep existing behavior; only percentage-based color-temperature properties use the new mapping.