### PR TITLE
Persist the IDs for cached sessions

### DIFF
--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -33,12 +33,16 @@ class MiCloud {
       length: 13,
       charset: 'ABCDEF',
     });
-    this.USERAGENT = `Android-7.1.1-1.0.0-ONEPLUS A3010-136-${this.AGENT_ID} APP/com.xiaomi.mihome APPV/10.5.201`;
+    this.USERAGENT = this._generateUserAgent();
     this.CLIENT_ID = randomstring.generate({
       length: 6,
       charset: 'alphabetic',
       capitalization: 'uppercase',
     });
+  }
+  
+  _generateUserAgent() {
+    return `Android-7.1.1-1.0.0-ONEPLUS A3010-136-${this.AGENT_ID} APP/com.xiaomi.mihome APPV/10.5.201`;
   }
 
   isLoggedIn() {
@@ -72,7 +76,10 @@ class MiCloud {
         userId: this.userId,
         serviceToken: this.serviceToken,
         timestamp: this.loginTimestamp,
-        loggedInAt: loggedInAtStr
+        loggedInAt: loggedInAtStr,
+        // Include the IDs within the token so they persist across reboot
+        agentId: this.AGENT_ID,
+        clientId: this.CLIENT_ID
       };
     }
   }
@@ -82,13 +89,22 @@ class MiCloud {
       const {
         ssecurity,
         userId,
-        serviceToken
+        serviceToken,
+        agentId,
+        clientId
       } = tokenJson;
 
       if (ssecurity && userId && serviceToken) {
         this.ssecurity = ssecurity;
         this.userId = userId;
         this.serviceToken = serviceToken;
+        
+        // Restore cached IDs after restarting host
+        if (agentId && clientId) {
+          this.AGENT_ID = agentId;
+          this.CLIENT_ID = clientId;
+          this.USERAGENT = this._generateUserAgent();
+        }
       }
     }
   }


### PR DESCRIPTION
Hopefully prevents the cached token from stopping working when the container or host restarts. IDs are stored alongside the token and are restored for cached sessions.