### PR TITLE
Add MiCloud QR login and prefer cached session for device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This is a global configuration object for the MiCloud connection. When specified
     - *password* - [required] the MiCloud password
     - *country* - [optional] the country where the servers are located for your devices. **Default: "cn"**
     - *forceMiCloud* - [optional] forces to use MiCloud even when the device supports local commands. **Default: false**
-    - *useCachedSession* - [optional] use a cached MiCloud session. Useful when 2FA is needed for the account. Use the homebrige ui to create a session. **Default: false**
+    - *useCachedSession* - [optional] use a cached MiCloud session. Useful when 2FA is needed for the account. Use the homebrige ui to create a session. The recommended flow is the QR code login because Xiaomi's password login can now require a browser-only auth flow. **Default: false**
     - *timeout* - [optional] set a custom request timeout in milliseconds. **Default: 5000**
 #### General device configuration fields
 - `name` [required]

--- a/README.md
+++ b/README.md
@@ -350,9 +350,11 @@ miot cloud list-devices
 
 miot cloud login --qr
 
-miot cloud login --qr --homebridge-storage /var/lib/homebridge
+miot cloud session
 
-miot cloud logout --homebridge-storage /var/lib/homebridge
+miot cloud session --storage homebridge --homebridge-storage /var/lib/homebridge
+
+miot cloud copy-session --from cli --to homebridge --homebridge-storage /var/lib/homebridge
 
 miot cloud get-props '[{"siid":2,"piid":2,"did":"<DID>"}]'
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ miot send <IP> -t <TOKEN> action '{"aiid":13,"in":[],"siid":10}'
 
 miot cloud list-devices
 
+miot cloud login --qr
+
 miot cloud get-props '[{"siid":2,"piid":2,"did":"<DID>"}]'
 
 miot cloud set-props '[{"siid":2,"piid":2,"value":1,"did":"<DID>"}]'

--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ miot cloud list-devices
 
 miot cloud login --qr
 
+miot cloud login --qr --homebridge-storage /var/lib/homebridge
+
+miot cloud logout --homebridge-storage /var/lib/homebridge
+
 miot cloud get-props '[{"siid":2,"piid":2,"did":"<DID>"}]'
 
 miot cloud set-props '[{"siid":2,"piid":2,"value":1,"did":"<DID>"}]'

--- a/cli/commands/cloud/copy-session.js
+++ b/cli/commands/cloud/copy-session.js
@@ -1,0 +1,85 @@
+const chalk = require('chalk');
+const log = require('../../log');
+const {
+  getSession,
+  setSession,
+  printSessionMetadata,
+  checkSession
+} = require('../../utils/cloud-session');
+
+exports.command = 'copy-session';
+exports.description = 'Copy a cached MiCloud session between CLI and Homebridge storage';
+exports.builder = {
+  from: {
+    type: 'string',
+    choices: ['cli', 'homebridge'],
+    demandOption: true,
+    description: 'Source cached session storage'
+  },
+  to: {
+    type: 'string',
+    choices: ['cli', 'homebridge'],
+    demandOption: true,
+    description: 'Destination cached session storage'
+  },
+  'homebridge-storage': {
+    type: 'string',
+    description: 'Homebridge storage path, used when either source or destination is homebridge'
+  },
+  force: {
+    type: 'boolean',
+    description: 'Overwrite an existing destination cached session'
+  },
+  check: {
+    type: 'boolean',
+    description: 'Validate the copied cached session with a read-only MiCloud device list request'
+  },
+  country: {
+    type: 'string',
+    default: 'cn',
+    description: 'MiCloud country to use for --check'
+  }
+};
+
+exports.handler = async argv => {
+  const {
+    from,
+    to,
+    homebridgeStorage,
+    force,
+    check,
+    country
+  } = argv;
+
+  try {
+    if (from === to) {
+      throw new Error(`Source and destination storage must be different.`);
+    }
+
+    const source = getSession(from, homebridgeStorage);
+    if (!source.tokenJson) {
+      throw new Error(`No MiCloud session found in ${from} storage.`);
+    }
+
+    const destination = getSession(to, homebridgeStorage);
+    if (destination.tokenJson && !force) {
+      throw new Error(`A MiCloud session already exists in ${to} storage. Use --force to overwrite it.`);
+    }
+
+    const destinationPath = setSession(to, homebridgeStorage, source.tokenJson);
+    log.success(`Copied MiCloud session from ${chalk.magenta.bold(from)} to ${chalk.magenta.bold(to)}.`);
+    printSessionMetadata(to, destinationPath, source.tokenJson);
+
+    if (check) {
+      log.info(`Checking copied session using country ${chalk.magenta.bold(country)}...`);
+      const result = await checkSession(source.tokenJson, country);
+      log.success(`Validity check: success. Country: ${result.country}. Devices visible: ${result.deviceCount}`);
+    } else {
+      log.info(`Validity check: skipped`);
+    }
+  } catch (err) {
+    log.error(err.message);
+  }
+
+  process.exit(0);
+};

--- a/cli/commands/cloud/login.js
+++ b/cli/commands/cloud/login.js
@@ -58,7 +58,7 @@ exports.handler = async argv => {
     const micloudFile = await fs.readFile(file, 'utf8');
     if (micloudFile) {
       log.info(`Found mi cloud credentials file at ${chalk.green.bold(file)}`);
-      micloudJson = JSON.parse(micloudFile);
+      const micloudJson = JSON.parse(micloudFile);
       username = micloudJson.username;
       password = micloudJson.password;
     } else {

--- a/cli/commands/cloud/login.js
+++ b/cli/commands/cloud/login.js
@@ -16,10 +16,6 @@ exports.builder = {
     default: 'zh_CN',
     description: 'Locale to use for QR login'
   },
-  'homebridge-storage': {
-    type: 'string',
-    description: 'Homebridge storage path where the cached MiCloud session should also be saved'
-  },
   username: {
     alias: 'u',
     type: 'string',
@@ -41,14 +37,13 @@ exports.handler = async argv => {
   let {
     qr,
     locale,
-    homebridgeStorage,
     username,
     password,
     file
   } = argv;
 
   if (qr) {
-    await loginWithQr(locale, homebridgeStorage);
+    await loginWithQr(locale);
     process.exit(0);
   }
 
@@ -82,7 +77,6 @@ exports.handler = async argv => {
   try {
     await MiCloudHelper.login(username, password);
     log.success(`Successfully logged in to MiCloud with username ${chalk.yellow.bold(username)}`);
-    saveHomebridgeSession(homebridgeStorage);
   } catch (err) {
     log.error(err.message);
   }
@@ -90,7 +84,7 @@ exports.handler = async argv => {
   process.exit(0);
 };
 
-async function loginWithQr(locale, homebridgeStorage) {
+async function loginWithQr(locale) {
   try {
     log.info(`Creating MiCloud QR login session...`);
     const qrLogin = await MiCloudHelper.createQrLogin(locale);
@@ -113,7 +107,6 @@ async function loginWithQr(locale, homebridgeStorage) {
       if (qrLoginData.success) {
         await MiCloudHelper.completeQrLogin(qrLoginData);
         log.success(`Successfully logged in to MiCloud using QR code.`);
-        saveHomebridgeSession(homebridgeStorage);
         return;
       }
 
@@ -132,13 +125,4 @@ async function loginWithQr(locale, homebridgeStorage) {
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function saveHomebridgeSession(homebridgeStorage) {
-  if (!homebridgeStorage) {
-    return;
-  }
-
-  MiCloudHelper.setHomebridgeCachedSession(homebridgeStorage, MiCloudHelper.getServiceToken());
-  log.success(`Successfully saved the MiCloud session to Homebridge storage at ${chalk.green.bold(homebridgeStorage)}`);
 }

--- a/cli/commands/cloud/login.js
+++ b/cli/commands/cloud/login.js
@@ -1,11 +1,21 @@
 const log = require('../../log');
 const chalk = require('chalk');
 const fs = require('fs').promises;
+const qrcode = require('qrcode-terminal');
 const MiCloudHelper = require('../../../lib/tools/MiCloudHelper');
 
 exports.command = 'login';
 exports.description = 'Log in to the MiCloud';
 exports.builder = {
+  qr: {
+    type: 'boolean',
+    description: 'Log in using a QR code'
+  },
+  locale: {
+    type: 'string',
+    default: 'zh_CN',
+    description: 'Locale to use for QR login'
+  },
   username: {
     alias: 'u',
     type: 'string',
@@ -25,10 +35,17 @@ exports.builder = {
 
 exports.handler = async argv => {
   let {
+    qr,
+    locale,
     username,
     password,
     file
   } = argv;
+
+  if (qr) {
+    await loginWithQr(locale);
+    process.exit(0);
+  }
 
   if (!file && (!username || !password)) {
     file = './micloudlogin.json';
@@ -66,3 +83,46 @@ exports.handler = async argv => {
 
   process.exit(0);
 };
+
+async function loginWithQr(locale) {
+  try {
+    log.info(`Creating MiCloud QR login session...`);
+    const qrLogin = await MiCloudHelper.createQrLogin(locale);
+    const qrValue = qrLogin.loginUrl || qrLogin.qr;
+    const pollInterval = Math.max(Number(qrLogin.timeInterval || 3), 2) * 1000;
+    const timeoutAt = Date.now() + (Number(qrLogin.timeout || 300) * 1000);
+
+    log.info(`Scan the QR code with the Mi Home app or Xiaomi account app, then approve the login.`);
+    qrcode.generate(qrValue, {
+      small: true
+    });
+
+    if (qrLogin.loginUrl) {
+      log.info(`If the QR code cannot be scanned, open this URL: ${chalk.cyan(qrLogin.loginUrl)}`);
+    }
+
+    while (Date.now() <= timeoutAt) {
+      await wait(pollInterval);
+      const qrLoginData = await MiCloudHelper.pollQrLogin(qrLogin.lp);
+      if (qrLoginData.success) {
+        await MiCloudHelper.completeQrLogin(qrLoginData);
+        log.success(`Successfully logged in to MiCloud using QR code.`);
+        return;
+      }
+
+      if (qrLoginData.desc) {
+        log.info(`Waiting for QR confirmation: ${qrLoginData.desc}`);
+      } else {
+        log.info(`Waiting for QR confirmation...`);
+      }
+    }
+
+    log.error(`QR login timed out. Please run the command again to create a new QR code.`);
+  } catch (err) {
+    log.error(err.message);
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/cli/commands/cloud/login.js
+++ b/cli/commands/cloud/login.js
@@ -16,6 +16,10 @@ exports.builder = {
     default: 'zh_CN',
     description: 'Locale to use for QR login'
   },
+  'homebridge-storage': {
+    type: 'string',
+    description: 'Homebridge storage path where the cached MiCloud session should also be saved'
+  },
   username: {
     alias: 'u',
     type: 'string',
@@ -37,13 +41,14 @@ exports.handler = async argv => {
   let {
     qr,
     locale,
+    homebridgeStorage,
     username,
     password,
     file
   } = argv;
 
   if (qr) {
-    await loginWithQr(locale);
+    await loginWithQr(locale, homebridgeStorage);
     process.exit(0);
   }
 
@@ -77,6 +82,7 @@ exports.handler = async argv => {
   try {
     await MiCloudHelper.login(username, password);
     log.success(`Successfully logged in to MiCloud with username ${chalk.yellow.bold(username)}`);
+    saveHomebridgeSession(homebridgeStorage);
   } catch (err) {
     log.error(err.message);
   }
@@ -84,7 +90,7 @@ exports.handler = async argv => {
   process.exit(0);
 };
 
-async function loginWithQr(locale) {
+async function loginWithQr(locale, homebridgeStorage) {
   try {
     log.info(`Creating MiCloud QR login session...`);
     const qrLogin = await MiCloudHelper.createQrLogin(locale);
@@ -107,6 +113,7 @@ async function loginWithQr(locale) {
       if (qrLoginData.success) {
         await MiCloudHelper.completeQrLogin(qrLoginData);
         log.success(`Successfully logged in to MiCloud using QR code.`);
+        saveHomebridgeSession(homebridgeStorage);
         return;
       }
 
@@ -125,4 +132,13 @@ async function loginWithQr(locale) {
 
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function saveHomebridgeSession(homebridgeStorage) {
+  if (!homebridgeStorage) {
+    return;
+  }
+
+  MiCloudHelper.setHomebridgeCachedSession(homebridgeStorage, MiCloudHelper.getServiceToken());
+  log.success(`Successfully saved the MiCloud session to Homebridge storage at ${chalk.green.bold(homebridgeStorage)}`);
 }

--- a/cli/commands/cloud/logout.js
+++ b/cli/commands/cloud/logout.js
@@ -1,27 +1,13 @@
 const log = require('../../log');
-const chalk = require('chalk');
 const MiCloudHelper = require('../../../lib/tools/MiCloudHelper');
 
 exports.command = 'logout';
 exports.description = 'Log out from the MiCloud';
-exports.builder = {
-  'homebridge-storage': {
-    type: 'string',
-    description: 'Homebridge storage path where the cached MiCloud session should also be cleared'
-  }
-};
+exports.builder = {};
 
 exports.handler = async argv => {
-  const {
-    homebridgeStorage
-  } = argv;
-
   MiCloudHelper.logout();
   log.success(`Successfully logged out from the MiCloud!`);
-  if (homebridgeStorage) {
-    MiCloudHelper.clearHomebridgeCachedSession(homebridgeStorage);
-    log.success(`Successfully cleared the MiCloud session from Homebridge storage at ${chalk.green.bold(homebridgeStorage)}`);
-  }
 
   process.exit(0);
 };

--- a/cli/commands/cloud/logout.js
+++ b/cli/commands/cloud/logout.js
@@ -4,11 +4,24 @@ const MiCloudHelper = require('../../../lib/tools/MiCloudHelper');
 
 exports.command = 'logout';
 exports.description = 'Log out from the MiCloud';
-exports.builder = {};
+exports.builder = {
+  'homebridge-storage': {
+    type: 'string',
+    description: 'Homebridge storage path where the cached MiCloud session should also be cleared'
+  }
+};
 
 exports.handler = async argv => {
+  const {
+    homebridgeStorage
+  } = argv;
+
   MiCloudHelper.logout();
   log.success(`Successfully logged out from the MiCloud!`);
+  if (homebridgeStorage) {
+    MiCloudHelper.clearHomebridgeCachedSession(homebridgeStorage);
+    log.success(`Successfully cleared the MiCloud session from Homebridge storage at ${chalk.green.bold(homebridgeStorage)}`);
+  }
 
   process.exit(0);
 };

--- a/cli/commands/cloud/session.js
+++ b/cli/commands/cloud/session.js
@@ -1,0 +1,61 @@
+const chalk = require('chalk');
+const log = require('../../log');
+const {
+  getSession,
+  printSessionMetadata,
+  checkSession
+} = require('../../utils/cloud-session');
+
+exports.command = 'session';
+exports.description = 'Inspect a cached MiCloud session';
+exports.builder = {
+  storage: {
+    type: 'string',
+    choices: ['cli', 'homebridge'],
+    default: 'cli',
+    description: 'Cached session storage to inspect'
+  },
+  'homebridge-storage': {
+    type: 'string',
+    description: 'Homebridge storage path, used when --storage homebridge is selected'
+  },
+  check: {
+    type: 'boolean',
+    description: 'Validate the cached session with a read-only MiCloud device list request'
+  },
+  country: {
+    type: 'string',
+    default: 'cn',
+    description: 'MiCloud country to use for --check'
+  }
+};
+
+exports.handler = async argv => {
+  const {
+    storage,
+    homebridgeStorage,
+    check,
+    country
+  } = argv;
+
+  try {
+    const {
+      storagePath,
+      tokenJson
+    } = getSession(storage, homebridgeStorage);
+
+    printSessionMetadata(storage, storagePath, tokenJson);
+
+    if (check) {
+      log.info(`Checking cached session using country ${chalk.magenta.bold(country)}...`);
+      const result = await checkSession(tokenJson, country);
+      log.success(`Validity check: success. Country: ${result.country}. Devices visible: ${result.deviceCount}`);
+    } else {
+      log.info(`Validity check: skipped`);
+    }
+  } catch (err) {
+    log.error(err.message);
+  }
+
+  process.exit(0);
+};

--- a/cli/utils/cloud-session.js
+++ b/cli/utils/cloud-session.js
@@ -1,0 +1,78 @@
+const chalk = require('chalk');
+const log = require('../log');
+const MiCloudHelper = require('../../lib/tools/MiCloudHelper');
+
+function getSession(storage, homebridgeStorage) {
+  if (storage === 'cli') {
+    return {
+      storagePath: MiCloudHelper.configFile,
+      tokenJson: MiCloudHelper.getCliCachedSession()
+    };
+  }
+
+  if (storage === 'homebridge') {
+    const storagePath = MiCloudHelper.getHomebridgeStoragePath(homebridgeStorage);
+    return {
+      storagePath,
+      tokenJson: MiCloudHelper.getHomebridgeCachedSession(storagePath)
+    };
+  }
+
+  throw new Error(`Unsupported session storage: ${storage}`);
+}
+
+function setSession(storage, homebridgeStorage, tokenJson) {
+  if (storage === 'cli') {
+    MiCloudHelper.setServiceToken(tokenJson);
+    return MiCloudHelper.configFile;
+  }
+
+  if (storage === 'homebridge') {
+    const storagePath = MiCloudHelper.getHomebridgeStoragePath(homebridgeStorage);
+    MiCloudHelper.setHomebridgeCachedSession(storagePath, tokenJson);
+    return storagePath;
+  }
+
+  throw new Error(`Unsupported session storage: ${storage}`);
+}
+
+function printSessionMetadata(storage, storagePath, tokenJson) {
+  log.info(`Storage: ${chalk.magenta.bold(storage)}`);
+  log.info(`Path: ${chalk.green.bold(storagePath)}`);
+
+  if (!tokenJson) {
+    log.warn(`MiCloud session found: no`);
+    return;
+  }
+
+  const metadata = MiCloudHelper.getSessionMetadata(tokenJson);
+  log.success(`MiCloud session found: yes`);
+  log.info(`Login time: ${metadata.loggedInAt}`);
+  log.info(`Login method: ${metadata.loginMethod}`);
+  log.info(`Timestamp age: ${metadata.age}`);
+
+  const table = Object.entries(metadata.fields).map(([field, value]) => {
+    return {
+      field,
+      present: value.present,
+      length: value.length,
+      sha256: value.sha256 || ''
+    };
+  });
+  log.table(table);
+}
+
+async function checkSession(tokenJson, country) {
+  if (!tokenJson) {
+    throw new Error(`No MiCloud session found.`);
+  }
+
+  return MiCloudHelper.checkSession(tokenJson, country);
+}
+
+module.exports = {
+  getSession,
+  setSession,
+  printSessionMetadata,
+  checkSession
+};

--- a/cli/utils/cloud-session.js
+++ b/cli/utils/cloud-session.js
@@ -47,7 +47,7 @@ function printSessionMetadata(storage, storagePath, tokenJson) {
 
   const metadata = MiCloudHelper.getSessionMetadata(tokenJson);
   log.success(`MiCloud session found: yes`);
-  log.info(`Login time: ${metadata.loggedInAt}`);
+  log.info(`Login time: ${metadata.displayLoggedInAt}`);
   log.info(`Login method: ${metadata.loginMethod}`);
   log.info(`Timestamp age: ${metadata.age}`);
 

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -283,15 +283,19 @@
       })
     }
 
-    // check wheter we have a cached micloud session
+    let hasCachedMiCloudSession = false;
+
+    // check whether we have a cached micloud session
     await updateCachedMiCloudSessionInfo();
 
     // helper to update the current micloud session cache info
     async function updateCachedMiCloudSessionInfo() {
       const cachedSessionResult = await homebridge.request('/get-cached-micloud-session', {});
       if (cachedSessionResult.success && cachedSessionResult.cachedSession) {
+        hasCachedMiCloudSession = true;
         $('#cachedMiCloudSessionStatusLbl').html("Cached MiCloud session found! Login time : " + cachedSessionResult.cachedSession.loggedInAt);
       } else {
+        hasCachedMiCloudSession = false;
         $('#cachedMiCloudSessionStatusLbl').html("No cached MiCloud session found!");
       }
     }
@@ -433,7 +437,7 @@
       let verifyUrl = twoFactorAuthLink.attr('href');
       let twoFaTicket = ticketInput.val();
 
-      if (username && password) {
+      if (hasCachedMiCloudSession || (username && password)) {
         $('.miot-message').hide();
         btn.prop('disabled', true).html('<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>');
         usernameInput.prop('disabled', true);
@@ -485,7 +489,7 @@
           showAllDevicesCheckbox.prop('disabled', false);
         })
       } else {
-        homebridge.toast.error('A username and password must be provided.', 'Error');
+        homebridge.toast.error('Login with QR code first, or provide a username and password.', 'Error');
       }
     });
 

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -85,6 +85,19 @@
       <div class="card-body">
         <label id="cachedMiCloudSessionStatusLbl" class="text-info fw-bold fs-5"></label>
         <form>
+          <div class="text-center mt-sm-3">
+            <button class="btn btn-success" id="createMiCloudQrLogin" type="button">Login to MiCloud with QR Code</button>
+          </div>
+          <div class="text-center mt-sm-3 qr-login-section-micloud-session miot-message" style="display: none">
+            <div class="alert alert-info" role="alert">
+              Scan this QR code with the Mi Home app or Xiaomi account app, then approve the login.
+            </div>
+            <img id="miCloudQrLoginImage" alt="MiCloud QR login" style="max-width: 260px; width: 100%; background: white; padding: 8px;">
+            <div class="mt-sm-3">
+              <a id="miCloudQrLoginUrl" href="#" target="_blank">Open QR login page</a>
+            </div>
+            <label id="miCloudQrLoginStatusLbl" class="text-info fw-bold fs-6"></label>
+          </div>
           <div class="form-row">
             <div class="col">
               <label for="userNameMiCloudSessionInput">Username</label>
@@ -522,6 +535,72 @@
         })
       } else {
         homebridge.toast.error('A username and password must be provided.', 'Error');
+      }
+    });
+
+    // login to MiCloud with QR code
+    $('#createMiCloudQrLogin').on('click', async function(e) {
+      e.preventDefault();
+      let btn = $(this),
+        qrSection = $('.qr-login-section-micloud-session'),
+        qrImage = $('#miCloudQrLoginImage'),
+        qrLoginUrl = $('#miCloudQrLoginUrl'),
+        qrStatus = $('#miCloudQrLoginStatusLbl');
+
+      $('.miot-message').hide();
+      btn.prop('disabled', true).html('<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>');
+      qrStatus.html('');
+
+      try {
+        const data = await homebridge.request('/create-micloud-qr-login', {});
+        if (!data.success) {
+          homebridge.toast.error(data.error || 'Could not create MiCloud QR login.', 'Login Error');
+          btn.prop('disabled', false).html("Login to MiCloud with QR Code");
+          return;
+        }
+
+        qrImage.attr('src', data.qr);
+        qrLoginUrl.attr('href', data.loginUrl || data.qr);
+        qrSection.show();
+        qrStatus.html('Waiting for QR scan confirmation...');
+
+        const pollInterval = Math.max(Number(data.timeInterval || 3), 2) * 1000;
+        const timeoutAt = Date.now() + (Number(data.timeout || 300) * 1000);
+
+        const poll = async function() {
+          if (Date.now() > timeoutAt) {
+            qrStatus.html('QR login timed out. Please create a new QR code.');
+            btn.prop('disabled', false).html("Login to MiCloud with QR Code");
+            return;
+          }
+
+          const pollData = await homebridge.request('/poll-micloud-qr-login', {
+            lp: data.lp
+          });
+
+          if (pollData.success) {
+            await updateCachedMiCloudSessionInfo();
+            qrStatus.html('MiCloud session successfully saved!');
+            homebridge.toast.success('Successfully cached the MiCloud session! You may now use it for device control.');
+            $('.micloud-session.miot-message').show();
+            btn.prop('disabled', false).html("Login to MiCloud with QR Code");
+            return;
+          }
+
+          if (pollData.pending) {
+            qrStatus.html(pollData.desc || 'Waiting for QR scan confirmation...');
+            setTimeout(poll, pollInterval);
+            return;
+          }
+
+          homebridge.toast.error(pollData.error || 'Could not complete MiCloud QR login.', 'Login Error');
+          btn.prop('disabled', false).html("Login to MiCloud with QR Code");
+        };
+
+        setTimeout(poll, pollInterval);
+      } catch (err) {
+        homebridge.toast.error(err.message || String(err), 'Login Error');
+        btn.prop('disabled', false).html("Login to MiCloud with QR Code");
       }
     });
 

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -293,7 +293,8 @@
       const cachedSessionResult = await homebridge.request('/get-cached-micloud-session', {});
       if (cachedSessionResult.success && cachedSessionResult.cachedSession) {
         hasCachedMiCloudSession = true;
-        $('#cachedMiCloudSessionStatusLbl').html("Cached MiCloud session found! Login time : " + cachedSessionResult.cachedSession.loggedInAt);
+        const loginMethod = cachedSessionResult.cachedSession.loginMethod || 'unknown';
+        $('#cachedMiCloudSessionStatusLbl').html("Cached MiCloud session found! Login time : " + cachedSessionResult.cachedSession.loggedInAt + ". Login method : " + loginMethod);
       } else {
         hasCachedMiCloudSession = false;
         $('#cachedMiCloudSessionStatusLbl').html("No cached MiCloud session found!");

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -294,7 +294,8 @@
       if (cachedSessionResult.success && cachedSessionResult.cachedSession) {
         hasCachedMiCloudSession = true;
         const loginMethod = cachedSessionResult.cachedSession.loginMethod || 'unknown';
-        $('#cachedMiCloudSessionStatusLbl').html("Cached MiCloud session found! Login time : " + cachedSessionResult.cachedSession.loggedInAt + ". Login method : " + loginMethod);
+        const loggedInAt = cachedSessionResult.cachedSession.displayLoggedInAt || cachedSessionResult.cachedSession.loggedInAt || 'unknown';
+        $('#cachedMiCloudSessionStatusLbl').html("Cached MiCloud session found! Login time : " + loggedInAt + ". Login method : " + loginMethod);
       } else {
         hasCachedMiCloudSession = false;
         $('#cachedMiCloudSessionStatusLbl').html("No cached MiCloud session found!");

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -37,7 +37,7 @@ class UiServer extends HomebridgePluginUiServer {
     const twoFaTicket = params.twoFaTicket;
     const isShowAll = !!params.isShowAll;
 
-    // try to login
+    // Continue an interactive 2FA login if the legacy password flow requested it.
     if (verifyUrl && twoFaTicket) {
       try {
         await miCloud.loginTwoFa(verifyUrl, twoFaTicket);
@@ -47,7 +47,17 @@ class UiServer extends HomebridgePluginUiServer {
           error: `2FA login failed with error: ` + err.message
         };
       }
+    } else if (await this.setCachedMiCloudSession(miCloud)) {
+      // Prefer the shared cached session created by QR login.
+      miCloud.logger.debug(`Using cached MiCloud session to fetch all devices.`);
     } else {
+      if (!username || !password) {
+        return {
+          success: false,
+          error: `No cached MiCloud session found. Please login with QR code or provide username and password.`
+        };
+      }
+
       try {
         await miCloud.login(username, password);
       } catch (err) {
@@ -290,6 +300,27 @@ class UiServer extends HomebridgePluginUiServer {
       }
     }
 
+  }
+
+  async setCachedMiCloudSession(miCloud) {
+    const cachedMiCloudSessionFile = this.homebridgeStoragePath + Constants.MICLOUD_SESSION_CACHE_LOCATION;
+
+    try {
+      const cachedSession = await fs.readFile(cachedMiCloudSessionFile, 'utf8');
+      if (!cachedSession) {
+        return false;
+      }
+
+      const cachedSessionParsed = JSON.parse(cachedSession);
+      if (!cachedSessionParsed) {
+        return false;
+      }
+
+      miCloud.setServiceToken(cachedSessionParsed);
+      return miCloud.isLoggedIn();
+    } catch (err) {
+      return false;
+    }
   }
 
 }

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -18,6 +18,8 @@ class UiServer extends HomebridgePluginUiServer {
     this.onRequest('/generate-device-class', this.generateDeviceClass.bind(this));
     this.onRequest('/get-device-metadata', this.getDeviceMetadata.bind(this));
     this.onRequest('/login-to-micloud', this.loginToMiCloud.bind(this));
+    this.onRequest('/create-micloud-qr-login', this.createMiCloudQrLogin.bind(this));
+    this.onRequest('/poll-micloud-qr-login', this.pollMiCloudQrLogin.bind(this));
     this.onRequest('/get-cached-micloud-session', this.getCachedMiCloudSession.bind(this));
 
     // this.ready() must be called to let the UI know you are ready to accept api calls
@@ -183,20 +185,8 @@ class UiServer extends HomebridgePluginUiServer {
 
     const serviceToken = miCloud.getServiceToken();
 
-    // check if the output directory exists, if not then create it recursively
-    const storagePath = this.homebridgeStoragePath + '/.miot_micloud/';
     try {
-      await fs.access(storagePath)
-    } catch (err) {
-      await fs.mkdir(storagePath, {
-        recursive: true
-      });
-    }
-
-    try {
-      const cachedMiCloudSessionFile = this.homebridgeStoragePath + Constants.MICLOUD_SESSION_CACHE_LOCATION;
-      const fileContent = JSON.stringify(serviceToken);
-      await fs.writeFile(cachedMiCloudSessionFile, fileContent, 'utf8');
+      await this.saveCachedMiCloudSession(serviceToken);
     } catch (err) {
       return {
         success: false,
@@ -208,6 +198,77 @@ class UiServer extends HomebridgePluginUiServer {
       success: true
     }
 
+  }
+
+  async createMiCloudQrLogin(params) {
+    const miCloud = new MiCloud(new Logger());
+    miCloud.setRequestTimeout(10000);
+
+    try {
+      const qrLogin = await miCloud.createQrLogin(params.locale || 'zh_CN');
+      return {
+        success: true,
+        qr: qrLogin.qr,
+        lp: qrLogin.lp,
+        loginUrl: qrLogin.loginUrl,
+        timeout: qrLogin.timeout,
+        timeInterval: qrLogin.timeInterval
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: `Failed to create MiCloud QR login: ` + err.message
+      };
+    }
+  }
+
+  async pollMiCloudQrLogin(params) {
+    const miCloud = new MiCloud(new Logger());
+    miCloud.setRequestTimeout(10000);
+
+    try {
+      const qrLoginData = await miCloud.pollQrLogin(params.lp);
+      if (!qrLoginData.success) {
+        return {
+          success: false,
+          pending: true,
+          code: qrLoginData.code,
+          desc: qrLoginData.desc
+        };
+      }
+
+      await miCloud.completeQrLogin(qrLoginData);
+      const serviceToken = miCloud.getServiceToken();
+      await this.saveCachedMiCloudSession(serviceToken);
+
+      return {
+        success: true,
+        cachedSession: {
+          loggedInAt: serviceToken.loggedInAt,
+          timestamp: serviceToken.timestamp
+        }
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: `Failed to complete MiCloud QR login: ` + err.message
+      };
+    }
+  }
+
+  async saveCachedMiCloudSession(serviceToken) {
+    const storagePath = this.homebridgeStoragePath + '/.miot_micloud/';
+    try {
+      await fs.access(storagePath)
+    } catch (err) {
+      await fs.mkdir(storagePath, {
+        recursive: true
+      });
+    }
+
+    const cachedMiCloudSessionFile = this.homebridgeStoragePath + Constants.MICLOUD_SESSION_CACHE_LOCATION;
+    const fileContent = JSON.stringify(serviceToken);
+    await fs.writeFile(cachedMiCloudSessionFile, fileContent, 'utf8');
   }
 
   async getCachedMiCloudSession(params) {

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -257,7 +257,7 @@ class UiServer extends HomebridgePluginUiServer {
         cachedSession: {
           loggedInAt: serviceToken.loggedInAt,
           timestamp: serviceToken.timestamp,
-          loginMethod: serviceToken.loginMethod || 'unknown'
+          loginMethod: serviceToken.loginMethod || Constants.LOGIN_METHOD.UNKNOWN
         }
       };
     } catch (err) {

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -7,6 +7,7 @@ const Constants = require('../lib/constants/Constants.js');
 const MiotSpecClassGenerator = require('../lib/tools/MiotSpecClassGenerator');
 const MiotSpecFetcher = require('../lib/protocol/MiotSpecFetcher');
 const Logger = require("../lib/utils/Logger");
+const TimeUtils = require('../lib/utils/TimeUtils.js');
 const fs = require('fs').promises;
 
 class UiServer extends HomebridgePluginUiServer {
@@ -289,6 +290,7 @@ class UiServer extends HomebridgePluginUiServer {
       const cachedSession = await fs.readFile(cachedMiCloudSessionFile, 'utf8');
       if (cachedSession) {
         let cachedSessionParsed = JSON.parse(cachedSession);
+        cachedSessionParsed.displayLoggedInAt = TimeUtils.getSessionLoginTime(cachedSessionParsed);
         return {
           success: true,
           cachedSession: cachedSessionParsed

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -255,7 +255,8 @@ class UiServer extends HomebridgePluginUiServer {
         success: true,
         cachedSession: {
           loggedInAt: serviceToken.loggedInAt,
-          timestamp: serviceToken.timestamp
+          timestamp: serviceToken.timestamp,
+          loginMethod: serviceToken.loginMethod || 'unknown'
         }
       };
     } catch (err) {

--- a/lib/constants/Constants.js
+++ b/lib/constants/Constants.js
@@ -5,5 +5,11 @@ module.exports = {
   FILTER_CHANGE_INDICATION_THRESHOLD: 5, // percentage
   BUTTON_RESET_TIMEOUT: 100, // in milliseconds
   SLIDER_DEBOUNCE: 500, // in milliseconds
-  MICLOUD_SESSION_CACHE_LOCATION: '/.miot_micloud/cachedSession'
+  MICLOUD_SESSION_CACHE_LOCATION: '/.miot_micloud/cachedSession',
+  LOGIN_METHOD: {
+    UNKNOWN: 'unknown',
+    PASSWORD: 'password',
+    PASSWORD_2FA: 'password_2fa',
+    QR: 'qr'
+  }
 };

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -67,6 +67,108 @@ class MiCloud {
     this.useUnencryptedRequests = unencrypted;
   }
 
+  async createQrLogin(locale = 'zh_CN') {
+    this.logger.debug(`(MiCloud) Creating QR login session`);
+    const url = new URL('https://account.xiaomi.com/longPolling/loginUrl');
+    url.searchParams.set('_qrsize', '480');
+    url.searchParams.set('qs', '?sid=xiaomiio&_json=true');
+    url.searchParams.set('callback', 'https://sts.api.io.mi.com/sts');
+    url.searchParams.set('_hasLogo', 'false');
+    url.searchParams.set('sid', 'xiaomiio');
+    url.searchParams.set('serviceParam', '');
+    url.searchParams.set('_locale', locale);
+    url.searchParams.set('_dc', String(Date.now()));
+
+    const res = await fetch(url.toString(), {
+      headers: {
+        'User-Agent': this.USERAGENT,
+      },
+    });
+    const content = await res.text();
+    this.logger.deepDebug(`(MiCloud) QR login session result: ${res.statusText} - ${content}`);
+
+    if (!res.ok) {
+      throw new Error(`QR login session request failed with status ${res.statusText}`);
+    }
+
+    const data = this._parseJson(content);
+    if (!data.qr || !data.lp) {
+      throw new Error('QR login session response is missing qr or lp URL');
+    }
+
+    return {
+      qr: data.qr,
+      lp: data.lp,
+      loginUrl: data.loginUrl,
+      timeout: data.timeout,
+      timeInterval: data.timeInterval,
+    };
+  }
+
+  async pollQrLogin(lpUrl) {
+    this.logger.debug(`(MiCloud) Polling QR login session`);
+    if (!lpUrl) {
+      throw new Error('Missing QR login polling URL');
+    }
+
+    const url = new URL(lpUrl);
+    url.searchParams.set('_', String(Date.now()));
+    const res = await fetch(url.toString(), {
+      headers: {
+        'User-Agent': this.USERAGENT,
+      },
+    });
+    const content = await res.text();
+    this.logger.deepDebug(`(MiCloud) QR login poll result: ${res.statusText} - ${content}`);
+
+    if (!res.ok) {
+      throw new Error(`QR login polling failed with status ${res.statusText}`);
+    }
+
+    const data = this._parseJson(content);
+    if (data.ssecurity && data.userId && data.location) {
+      return {
+        success: true,
+        ssecurity: data.ssecurity,
+        userId: data.userId,
+        cUserId: data.cUserId,
+        passToken: data.passToken,
+        location: data.location,
+      };
+    }
+
+    return {
+      success: false,
+      code: data.code,
+      desc: data.desc || data.description || data.message || data.status,
+    };
+  }
+
+  async completeQrLogin(qrLoginData) {
+    this.logger.debug(`(MiCloud) Completing QR login`);
+    if (!qrLoginData || !qrLoginData.ssecurity || !qrLoginData.userId || !qrLoginData.location) {
+      throw new Error('QR login data is incomplete');
+    }
+
+    this._cookieJar = {};
+    this.ssecurity = qrLoginData.ssecurity;
+    this.userId = qrLoginData.userId;
+    if (qrLoginData.cUserId) {
+      this._cookieJar.cUserId = qrLoginData.cUserId;
+    }
+    if (qrLoginData.passToken) {
+      this._cookieJar.passToken = qrLoginData.passToken;
+    }
+    this._cookieJar.userId = qrLoginData.userId;
+
+    const {
+      serviceToken
+    } = await this._loginStep3(qrLoginData.location);
+    this.serviceToken = serviceToken;
+    this.loginTimestamp = Date.now();
+    this.logger.debug(`(MiCloud) QR login successful!`);
+  }
+
 
   getServiceToken() {
     if (this.isLoggedIn()) {
@@ -91,13 +193,17 @@ class MiCloud {
         userId,
         serviceToken,
         agentId,
-        clientId
+        clientId,
+        timestamp,
+        loggedInAt,
+        capturedAt
       } = tokenJson;
 
       if (ssecurity && userId && serviceToken) {
         this.ssecurity = ssecurity;
         this.userId = userId;
         this.serviceToken = serviceToken;
+        this.loginTimestamp = timestamp || loggedInAt || capturedAt || this.loginTimestamp;
         
         // Restore cached IDs after restarting host
         if (agentId && clientId) {
@@ -417,6 +523,10 @@ class MiCloud {
     if (str.indexOf('&&&START&&&') === 0) {
       str = str.replace('&&&START&&&', '');
     }
+    const jsonpMatch = str.match(/^[^(]+\((.*)\);?$/s);
+    if (jsonpMatch) {
+      str = jsonpMatch[1];
+    }
     return JSON.parse(str);
   }
 
@@ -601,7 +711,12 @@ class MiCloud {
 
   async _loginStep3(location) {
     const url = location;
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': this.USERAGENT,
+        Cookie: this._cookieHeader(),
+      },
+    });
 
     const content = await res.text();
     const {
@@ -617,6 +732,9 @@ class MiCloud {
     const headers = res.headers.raw();
     const cookies = headers['set-cookie'];
     let serviceToken;
+    if (!cookies || !cookies.forEach) {
+      throw new Error('Login step 3 failed');
+    }
     cookies.forEach(cookieStr => {
       const cookie = cookieStr.split('; ')[0];
       const idx = cookie.indexOf('=');
@@ -626,6 +744,7 @@ class MiCloud {
         serviceToken = value;
       }
     });
+    this._storeSetCookies(res);
     if (!serviceToken) {
       throw new Error('Login step 3 failed');
     }

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -4,6 +4,7 @@ const randomstring = require('randomstring');
 const querystring = require('querystring');
 const Errors = require("../utils/Errors.js");
 const CustomCryptRC4 = require("../utils/CustomCryptRC4.js");
+const TimeUtils = require("../utils/TimeUtils.js");
 
 const DEFAULT_EQUEST_TIMEOUT = 5000;
 
@@ -174,13 +175,12 @@ class MiCloud {
 
   getServiceToken() {
     if (this.isLoggedIn()) {
-      const loggedInAtStr = new Date(this.loginTimestamp).toISOString().slice(0, 19).replace('T', ' ');
       return {
         ssecurity: this.ssecurity,
         userId: this.userId,
         serviceToken: this.serviceToken,
         timestamp: this.loginTimestamp,
-        loggedInAt: loggedInAtStr,
+        loggedInAt: TimeUtils.formatLocalTime(this.loginTimestamp),
         loginMethod: this.loginMethod || 'unknown',
         // Include the IDs within the token so they persist across reboot
         agentId: this.AGENT_ID,

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -16,6 +16,7 @@ class MiCloud {
     this.ssecurity = null;
     this.userId = null;
     this.serviceToken = null;
+    this.loginMethod = null;
 
     this.loginTimestamp = null;
 
@@ -165,6 +166,7 @@ class MiCloud {
       serviceToken
     } = await this._loginStep3(qrLoginData.location);
     this.serviceToken = serviceToken;
+    this.loginMethod = 'qr';
     this.loginTimestamp = Date.now();
     this.logger.debug(`(MiCloud) QR login successful!`);
   }
@@ -179,6 +181,7 @@ class MiCloud {
         serviceToken: this.serviceToken,
         timestamp: this.loginTimestamp,
         loggedInAt: loggedInAtStr,
+        loginMethod: this.loginMethod || 'unknown',
         // Include the IDs within the token so they persist across reboot
         agentId: this.AGENT_ID,
         clientId: this.CLIENT_ID
@@ -194,13 +197,15 @@ class MiCloud {
         serviceToken,
         agentId,
         clientId,
-        timestamp
+        timestamp,
+        loginMethod
       } = tokenJson;
 
       if (ssecurity && userId && serviceToken) {
         this.ssecurity = ssecurity;
         this.userId = userId;
         this.serviceToken = serviceToken;
+        this.loginMethod = loginMethod || 'unknown';
         if (typeof timestamp === 'number') {
           this.loginTimestamp = timestamp;
         }
@@ -239,6 +244,7 @@ class MiCloud {
     this.ssecurity = ssecurity;
     this.userId = userId;
     this.serviceToken = serviceToken;
+    this.loginMethod = 'password';
     this.loginTimestamp = Date.now();
   }
 
@@ -319,6 +325,7 @@ class MiCloud {
 
     if (this.ssecurity && this.userId && this.serviceToken) {
       this.logger.debug(`(MiCloud) 2FA login successful!`);
+      this.loginMethod = 'password_2fa';
       this.loginTimestamp = Date.now();
     } else {
       throw new Error(`2FA login failed! Did not find required data...`);
@@ -335,6 +342,7 @@ class MiCloud {
     this.ssecurity = null;
     this.userId = null;
     this.serviceToken = null;
+    this.loginMethod = null;
     this.loginTimestamp = null;
     this._cookieJar = {};
     this.setCountry('cn');
@@ -345,6 +353,7 @@ class MiCloud {
     this.ssecurity = null;
     this.userId = null;
     this.serviceToken = null;
+    this.loginMethod = null;
     this.loginTimestamp = null;
     this.login(this.username, this.password);
   }

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -194,16 +194,16 @@ class MiCloud {
         serviceToken,
         agentId,
         clientId,
-        timestamp,
-        loggedInAt,
-        capturedAt
+        timestamp
       } = tokenJson;
 
       if (ssecurity && userId && serviceToken) {
         this.ssecurity = ssecurity;
         this.userId = userId;
         this.serviceToken = serviceToken;
-        this.loginTimestamp = timestamp || loggedInAt || capturedAt || this.loginTimestamp;
+        if (typeof timestamp === 'number') {
+          this.loginTimestamp = timestamp;
+        }
         
         // Restore cached IDs after restarting host
         if (agentId && clientId) {

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -5,6 +5,7 @@ const querystring = require('querystring');
 const Errors = require("../utils/Errors.js");
 const CustomCryptRC4 = require("../utils/CustomCryptRC4.js");
 const TimeUtils = require("../utils/TimeUtils.js");
+const Constants = require('../constants/Constants.js');
 
 const DEFAULT_EQUEST_TIMEOUT = 5000;
 
@@ -152,22 +153,24 @@ class MiCloud {
       throw new Error('QR login data is incomplete');
     }
 
-    this._cookieJar = {};
-    this.ssecurity = qrLoginData.ssecurity;
-    this.userId = qrLoginData.userId;
+    const cookieJar = {
+      userId: qrLoginData.userId
+    };
     if (qrLoginData.cUserId) {
-      this._cookieJar.cUserId = qrLoginData.cUserId;
+      cookieJar.cUserId = qrLoginData.cUserId;
     }
     if (qrLoginData.passToken) {
-      this._cookieJar.passToken = qrLoginData.passToken;
+      cookieJar.passToken = qrLoginData.passToken;
     }
-    this._cookieJar.userId = qrLoginData.userId;
 
     const {
       serviceToken
-    } = await this._loginStep3(qrLoginData.location);
+    } = await this._loginStep3(qrLoginData.location, cookieJar);
+    this._cookieJar = cookieJar;
+    this.ssecurity = qrLoginData.ssecurity;
+    this.userId = qrLoginData.userId;
     this.serviceToken = serviceToken;
-    this.loginMethod = 'qr';
+    this.loginMethod = Constants.LOGIN_METHOD.QR;
     this.loginTimestamp = Date.now();
     this.logger.debug(`(MiCloud) QR login successful!`);
   }
@@ -181,7 +184,7 @@ class MiCloud {
         serviceToken: this.serviceToken,
         timestamp: this.loginTimestamp,
         loggedInAt: TimeUtils.formatLocalTime(this.loginTimestamp),
-        loginMethod: this.loginMethod || 'unknown',
+        loginMethod: this.loginMethod || Constants.LOGIN_METHOD.UNKNOWN,
         // Include the IDs within the token so they persist across reboot
         agentId: this.AGENT_ID,
         clientId: this.CLIENT_ID
@@ -205,7 +208,7 @@ class MiCloud {
         this.ssecurity = ssecurity;
         this.userId = userId;
         this.serviceToken = serviceToken;
-        this.loginMethod = loginMethod || 'unknown';
+        this.loginMethod = loginMethod || Constants.LOGIN_METHOD.UNKNOWN;
         if (typeof timestamp === 'number') {
           this.loginTimestamp = timestamp;
         }
@@ -244,7 +247,7 @@ class MiCloud {
     this.ssecurity = ssecurity;
     this.userId = userId;
     this.serviceToken = serviceToken;
-    this.loginMethod = 'password';
+    this.loginMethod = Constants.LOGIN_METHOD.PASSWORD;
     this.loginTimestamp = Date.now();
   }
 
@@ -325,7 +328,7 @@ class MiCloud {
 
     if (this.ssecurity && this.userId && this.serviceToken) {
       this.logger.debug(`(MiCloud) 2FA login successful!`);
-      this.loginMethod = 'password_2fa';
+      this.loginMethod = Constants.LOGIN_METHOD.PASSWORD_2FA;
       this.loginTimestamp = Date.now();
     } else {
       throw new Error(`2FA login failed! Did not find required data...`);
@@ -718,12 +721,12 @@ class MiCloud {
     };
   }
 
-  async _loginStep3(location) {
+  async _loginStep3(location, cookieJar = this._cookieJar) {
     const url = location;
     const res = await fetch(url, {
       headers: {
         'User-Agent': this.USERAGENT,
-        Cookie: this._cookieHeader(),
+        Cookie: this._cookieHeader([], cookieJar),
       },
     });
 
@@ -753,7 +756,7 @@ class MiCloud {
         serviceToken = value;
       }
     });
-    this._storeSetCookies(res);
+    this._storeSetCookies(res, cookieJar);
     if (!serviceToken) {
       throw new Error('Login step 3 failed');
     }
@@ -850,7 +853,7 @@ class MiCloud {
   }
 
   // --- cookie jar helpers ---
-  _storeSetCookies(res) {
+  _storeSetCookies(res, cookieJar = this._cookieJar) {
     try {
       const raw = res.headers && typeof res.headers.raw === 'function' ? res.headers.raw() : {};
       const setCookies = raw && raw['set-cookie'] ? raw['set-cookie'] : [];
@@ -862,21 +865,21 @@ class MiCloud {
         if (idx > 0) {
           const key = cookie.substr(0, idx).trim();
           const value = cookie.substr(idx + 1).trim();
-          this._cookieJar[key] = value;
+          cookieJar[key] = value;
         }
       });
     } catch (e) {
-      this.logger.deepDebug(`(MiCloud) Cookie Jar - Error parsing cookie. Reason: ${err.message}`);
+      this.logger.deepDebug(`(MiCloud) Cookie Jar - Error parsing cookie. Reason: ${e.message}`);
     }
   }
 
-  _cookieHeader(extraPairs = []) {
+  _cookieHeader(extraPairs = [], cookieJar = this._cookieJar) {
     const parts = [
       'sdkVersion=accountsdk-18.8.15',
       `deviceId=${this.CLIENT_ID}`
     ];
 
-    for (const [k, v] of Object.entries(this._cookieJar)) {
+    for (const [k, v] of Object.entries(cookieJar)) {
       parts.push(`${k}=${v}`);
     }
 

--- a/lib/protocol/MiCloud.js
+++ b/lib/protocol/MiCloud.js
@@ -153,20 +153,19 @@ class MiCloud {
       throw new Error('QR login data is incomplete');
     }
 
-    const cookieJar = {
+    this._cookieJar = {
       userId: qrLoginData.userId
     };
     if (qrLoginData.cUserId) {
-      cookieJar.cUserId = qrLoginData.cUserId;
+      this._cookieJar.cUserId = qrLoginData.cUserId;
     }
     if (qrLoginData.passToken) {
-      cookieJar.passToken = qrLoginData.passToken;
+      this._cookieJar.passToken = qrLoginData.passToken;
     }
 
     const {
       serviceToken
-    } = await this._loginStep3(qrLoginData.location, cookieJar);
-    this._cookieJar = cookieJar;
+    } = await this._loginStep3(qrLoginData.location);
     this.ssecurity = qrLoginData.ssecurity;
     this.userId = qrLoginData.userId;
     this.serviceToken = serviceToken;
@@ -721,12 +720,12 @@ class MiCloud {
     };
   }
 
-  async _loginStep3(location, cookieJar = this._cookieJar) {
+  async _loginStep3(location) {
     const url = location;
     const res = await fetch(url, {
       headers: {
         'User-Agent': this.USERAGENT,
-        Cookie: this._cookieHeader([], cookieJar),
+        Cookie: this._cookieHeader(),
       },
     });
 
@@ -745,7 +744,7 @@ class MiCloud {
     const cookies = headers['set-cookie'];
     let serviceToken;
     if (!cookies || !cookies.forEach) {
-      throw new Error('Login step 3 failed');
+      throw new Error('Login step 3 failed: no Set-Cookie header found');
     }
     cookies.forEach(cookieStr => {
       const cookie = cookieStr.split('; ')[0];
@@ -756,7 +755,7 @@ class MiCloud {
         serviceToken = value;
       }
     });
-    this._storeSetCookies(res, cookieJar);
+    this._storeSetCookies(res);
     if (!serviceToken) {
       throw new Error('Login step 3 failed');
     }
@@ -853,7 +852,7 @@ class MiCloud {
   }
 
   // --- cookie jar helpers ---
-  _storeSetCookies(res, cookieJar = this._cookieJar) {
+  _storeSetCookies(res) {
     try {
       const raw = res.headers && typeof res.headers.raw === 'function' ? res.headers.raw() : {};
       const setCookies = raw && raw['set-cookie'] ? raw['set-cookie'] : [];
@@ -865,7 +864,7 @@ class MiCloud {
         if (idx > 0) {
           const key = cookie.substr(0, idx).trim();
           const value = cookie.substr(idx + 1).trim();
-          cookieJar[key] = value;
+          this._cookieJar[key] = value;
         }
       });
     } catch (e) {
@@ -873,13 +872,13 @@ class MiCloud {
     }
   }
 
-  _cookieHeader(extraPairs = [], cookieJar = this._cookieJar) {
+  _cookieHeader(extraPairs = []) {
     const parts = [
       'sdkVersion=accountsdk-18.8.15',
       `deviceId=${this.CLIENT_ID}`
     ];
 
-    for (const [k, v] of Object.entries(cookieJar)) {
+    for (const [k, v] of Object.entries(this._cookieJar)) {
       parts.push(`${k}=${v}`);
     }
 

--- a/lib/protocol/MiotDevice.js
+++ b/lib/protocol/MiotDevice.js
@@ -17,6 +17,7 @@ const Errors = require("../utils/Errors.js");
 const MiotProtocolUtils = require('../utils/MiotProtocolUtils.js');
 const MiCloudUtils = require('../utils/MiCloudUtils.js');
 const ErrorUtils = require('../utils/ErrorUtils.js');
+const TimeUtils = require('../utils/TimeUtils.js');
 
 const COMMAND_GET = 'get_properties';
 const COMMAND_SET = 'set_properties';
@@ -403,7 +404,7 @@ class MiotDevice extends EventEmitter {
         if (this._getMiCloudUseCachedSession()) {
           if (this._getCachedMiCloudSession()) {
             const cachedSession = this._getCachedMiCloudSession();
-            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${cachedSession.loggedInAt}; login method: ${cachedSession.loginMethod || 'unknown'}`);
+            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${TimeUtils.getSessionLoginTime(cachedSession)}; login method: ${cachedSession.loginMethod || 'unknown'}`);
             this.miCloud.setServiceToken(cachedSession);
             needsLogin = false;
           } else {

--- a/lib/protocol/MiotDevice.js
+++ b/lib/protocol/MiotDevice.js
@@ -404,7 +404,7 @@ class MiotDevice extends EventEmitter {
         if (this._getMiCloudUseCachedSession()) {
           if (this._getCachedMiCloudSession()) {
             const cachedSession = this._getCachedMiCloudSession();
-            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${TimeUtils.getSessionLoginTime(cachedSession)}; login method: ${cachedSession.loginMethod || 'unknown'}`);
+            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${TimeUtils.getSessionLoginTime(cachedSession)}; login method: ${cachedSession.loginMethod || Constants.LOGIN_METHOD.UNKNOWN}`);
             this.miCloud.setServiceToken(cachedSession);
             needsLogin = false;
           } else {

--- a/lib/protocol/MiotDevice.js
+++ b/lib/protocol/MiotDevice.js
@@ -402,8 +402,9 @@ class MiotDevice extends EventEmitter {
         let needsLogin = true;
         if (this._getMiCloudUseCachedSession()) {
           if (this._getCachedMiCloudSession()) {
-            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${this._getCachedMiCloudSession().loggedInAt}`);
-            this.miCloud.setServiceToken(this._getCachedMiCloudSession());
+            const cachedSession = this._getCachedMiCloudSession();
+            this.logger.info(`Using cached session for MiCloud connection! Session login time: ${cachedSession.loggedInAt}; login method: ${cachedSession.loginMethod || 'unknown'}`);
+            this.miCloud.setServiceToken(cachedSession);
             needsLogin = false;
           } else {
             if (this._hasMiCloudCredentials()) {

--- a/lib/tools/MiCloudHelper.js
+++ b/lib/tools/MiCloudHelper.js
@@ -5,6 +5,7 @@ const miotPaths = envPaths('miot');
 const MiCloud = require('../protocol/MiCloud');
 const Logger = require("../utils/Logger");
 const Errors = require("../utils/Errors.js");
+const Constants = require('../constants/Constants.js');
 
 
 class MiCloudHelper {
@@ -169,9 +170,41 @@ class MiCloudHelper {
     return this.micloud['serviceToken'];
   }
 
+  setHomebridgeCachedSession(homebridgeStoragePath, tokenJson) {
+    if (!homebridgeStoragePath) {
+      throw new Error(`Missing Homebridge storage path!`);
+    }
+    if (!tokenJson) {
+      throw new Error(`Missing MiCloud service token!`);
+    }
+
+    const storagePath = path.join(homebridgeStoragePath, '.miot_micloud');
+    fs.mkdirSync(storagePath, {
+      recursive: true
+    });
+    fs.writeFileSync(this._getHomebridgeCachedSessionFile(homebridgeStoragePath), JSON.stringify(tokenJson), 'utf8');
+  }
+
+  clearHomebridgeCachedSession(homebridgeStoragePath) {
+    if (!homebridgeStoragePath) {
+      throw new Error(`Missing Homebridge storage path!`);
+    }
+
+    try {
+      fs.unlinkSync(this._getHomebridgeCachedSessionFile(homebridgeStoragePath));
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+
 
   /*----------========== PRIVATE ==========----------*/
 
+  _getHomebridgeCachedSessionFile(homebridgeStoragePath) {
+    return path.join(homebridgeStoragePath, Constants.MICLOUD_SESSION_CACHE_LOCATION.replace(/^\//, ''));
+  }
 
 }
 

--- a/lib/tools/MiCloudHelper.js
+++ b/lib/tools/MiCloudHelper.js
@@ -64,6 +64,19 @@ class MiCloudHelper {
     }
   }
 
+  async createQrLogin(locale) {
+    return this.miCloud.createQrLogin(locale);
+  }
+
+  async pollQrLogin(lpUrl) {
+    return this.miCloud.pollQrLogin(lpUrl);
+  }
+
+  async completeQrLogin(qrLoginData) {
+    await this.miCloud.completeQrLogin(qrLoginData);
+    this.setServiceToken(this.miCloud.getServiceToken());
+  }
+
   logout() {
     this.setServiceToken(null);
   }

--- a/lib/tools/MiCloudHelper.js
+++ b/lib/tools/MiCloudHelper.js
@@ -7,6 +7,7 @@ const MiCloud = require('../protocol/MiCloud');
 const Logger = require("../utils/Logger");
 const Errors = require("../utils/Errors.js");
 const Constants = require('../constants/Constants.js');
+const TimeUtils = require('../utils/TimeUtils.js');
 
 
 class MiCloudHelper {
@@ -239,6 +240,7 @@ class MiCloudHelper {
 
     const metadata = {
       loggedInAt: tokenJson.loggedInAt || 'unknown',
+      displayLoggedInAt: TimeUtils.getSessionLoginTime(tokenJson),
       loginMethod: tokenJson.loginMethod || 'unknown',
       timestamp: typeof tokenJson.timestamp === 'number' ? tokenJson.timestamp : null,
       age: typeof tokenJson.timestamp === 'number' ? this._formatAge(Date.now() - tokenJson.timestamp) : 'unknown',

--- a/lib/tools/MiCloudHelper.js
+++ b/lib/tools/MiCloudHelper.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const crypto = require('crypto');
 const envPaths = require('env-paths');
 const miotPaths = envPaths('miot');
@@ -196,12 +197,17 @@ class MiCloudHelper {
       return homebridgeStoragePath;
     }
 
-    const defaultHomebridgeStoragePath = '/var/lib/homebridge';
-    if (fs.existsSync(defaultHomebridgeStoragePath)) {
-      return defaultHomebridgeStoragePath;
+    const candidates = [
+      '/var/lib/homebridge',
+      path.join(os.homedir(), '.homebridge')
+    ];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
 
-    throw new Error(`Missing Homebridge storage path! Please specify --homebridge-storage <path>.`);
+    throw new Error(`Could not auto-detect Homebridge storage path. Please specify --homebridge-storage <path>. Common locations: /var/lib/homebridge (systemd), ~/.homebridge (user install).`);
   }
 
   setHomebridgeCachedSession(homebridgeStoragePath, tokenJson) {
@@ -241,7 +247,7 @@ class MiCloudHelper {
     const metadata = {
       loggedInAt: tokenJson.loggedInAt || 'unknown',
       displayLoggedInAt: TimeUtils.getSessionLoginTime(tokenJson),
-      loginMethod: tokenJson.loginMethod || 'unknown',
+      loginMethod: tokenJson.loginMethod || Constants.LOGIN_METHOD.UNKNOWN,
       timestamp: typeof tokenJson.timestamp === 'number' ? tokenJson.timestamp : null,
       age: typeof tokenJson.timestamp === 'number' ? this._formatAge(Date.now() - tokenJson.timestamp) : 'unknown',
       fields: {}

--- a/lib/tools/MiCloudHelper.js
+++ b/lib/tools/MiCloudHelper.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 const envPaths = require('env-paths');
 const miotPaths = envPaths('miot');
 const MiCloud = require('../protocol/MiCloud');
@@ -170,6 +171,38 @@ class MiCloudHelper {
     return this.micloud['serviceToken'];
   }
 
+  getCliCachedSession() {
+    return this.getServiceToken();
+  }
+
+  getHomebridgeCachedSession(homebridgeStoragePath) {
+    if (!homebridgeStoragePath) {
+      throw new Error(`Missing Homebridge storage path!`);
+    }
+
+    try {
+      return JSON.parse(fs.readFileSync(this._getHomebridgeCachedSessionFile(homebridgeStoragePath), 'utf8'));
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  getHomebridgeStoragePath(homebridgeStoragePath) {
+    if (homebridgeStoragePath) {
+      return homebridgeStoragePath;
+    }
+
+    const defaultHomebridgeStoragePath = '/var/lib/homebridge';
+    if (fs.existsSync(defaultHomebridgeStoragePath)) {
+      return defaultHomebridgeStoragePath;
+    }
+
+    throw new Error(`Missing Homebridge storage path! Please specify --homebridge-storage <path>.`);
+  }
+
   setHomebridgeCachedSession(homebridgeStoragePath, tokenJson) {
     if (!homebridgeStoragePath) {
       throw new Error(`Missing Homebridge storage path!`);
@@ -199,11 +232,85 @@ class MiCloudHelper {
     }
   }
 
+  getSessionMetadata(tokenJson) {
+    if (!tokenJson) {
+      return null;
+    }
+
+    const metadata = {
+      loggedInAt: tokenJson.loggedInAt || 'unknown',
+      loginMethod: tokenJson.loginMethod || 'unknown',
+      timestamp: typeof tokenJson.timestamp === 'number' ? tokenJson.timestamp : null,
+      age: typeof tokenJson.timestamp === 'number' ? this._formatAge(Date.now() - tokenJson.timestamp) : 'unknown',
+      fields: {}
+    };
+
+    ['userId', 'ssecurity', 'serviceToken', 'cUserId', 'passToken', 'agentId', 'clientId'].forEach(field => {
+      metadata.fields[field] = this._getRedactedFieldMetadata(tokenJson[field]);
+    });
+
+    return metadata;
+  }
+
+  async checkSession(tokenJson, country) {
+    if (!tokenJson) {
+      throw new Error(`Missing MiCloud service token!`);
+    }
+
+    const miCloud = new MiCloud(new Logger());
+    miCloud.setServiceToken(tokenJson);
+    miCloud.setRequestTimeout(this.requestTimeout);
+    miCloud.setCountry(country || this.getDefaultCountry() || 'cn');
+
+    const devices = await miCloud.getDevices();
+    return {
+      success: true,
+      country: miCloud.country,
+      deviceCount: Array.isArray(devices) ? devices.length : 0
+    };
+  }
+
 
   /*----------========== PRIVATE ==========----------*/
 
   _getHomebridgeCachedSessionFile(homebridgeStoragePath) {
     return path.join(homebridgeStoragePath, Constants.MICLOUD_SESSION_CACHE_LOCATION.replace(/^\//, ''));
+  }
+
+  _getRedactedFieldMetadata(value) {
+    if (!value) {
+      return {
+        present: false,
+        length: 0,
+        sha256: null
+      };
+    }
+
+    const stringValue = String(value);
+    return {
+      present: true,
+      length: stringValue.length,
+      sha256: crypto.createHash('sha256').update(stringValue).digest('hex').slice(0, 8)
+    };
+  }
+
+  _formatAge(ageMs) {
+    if (!Number.isFinite(ageMs) || ageMs < 0) {
+      return 'unknown';
+    }
+
+    const totalMinutes = Math.floor(ageMs / 60000);
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+
+    if (days > 0) {
+      return `${days}d ${hours}h ${minutes}m`;
+    }
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
   }
 
 }

--- a/lib/utils/TimeUtils.js
+++ b/lib/utils/TimeUtils.js
@@ -1,0 +1,32 @@
+function formatLocalTime(timestamp) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'unknown';
+  }
+
+  const pad = value => String(value).padStart(2, '0');
+  const offsetMinutes = -date.getTimezoneOffset();
+  const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+  const absOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = pad(Math.floor(absOffsetMinutes / 60));
+  const offsetRemainderMinutes = pad(absOffsetMinutes % 60);
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} GMT${offsetSign}${offsetHours}:${offsetRemainderMinutes}`;
+}
+
+function getSessionLoginTime(tokenJson) {
+  if (!tokenJson) {
+    return 'unknown';
+  }
+
+  if (typeof tokenJson.timestamp === 'number') {
+    return formatLocalTime(tokenJson.timestamp);
+  }
+
+  return tokenJson.loggedInAt || 'unknown';
+}
+
+module.exports = {
+  formatLocalTime,
+  getSessionLoginTime
+};

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "color-convert": "^2.0.1",
     "yargs": "^17.3.1",
     "chalk": "^4.1.2",
+    "qrcode-terminal": "^0.12.0",
     "env-paths": "^2.2.1"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Add a MiCloud QR login flow to the Homebridge UI.
- Save the same-round `userId`, `ssecurity`, and `serviceToken` into the existing cached session file.
- Prefer cached MiCloud sessions when discovering devices from the UI.
- Keep the existing username/password login as a fallback.

## Why
Xiaomi account password login can now enter a browser/authStart flow where the old API-based 2FA assumptions are no longer reliable. In particular, `serviceToken` and `ssecurity` must come from the same login round; mixing an old cached `ssecurity` with a new browser cookie token produces invalid signatures.

QR login provides a browser-compatible login path while still producing the credentials needed by the existing MiCloud API client.

## Validation
- Verified QR login can create a cached MiCloud session.
- Verified the cached session can call MiCloud device list APIs.
- Verified UI device discovery can use the cached session without requiring username/password input.
- Existing username/password flow remains available as fallback.

<img width="572" height="524" alt="image" src="https://github.com/user-attachments/assets/85b16980-4fb6-48de-a567-099fc8d9abed" />
