### PR TITLE
Fix cuco cp1 unsupported indicator light polling

### DIFF
--- a/lib/modules/outlet/devices/cuco.plug.cp1.js
+++ b/lib/modules/outlet/devices/cuco.plug.cp1.js
@@ -33,12 +33,10 @@ class CucoPlugCp1 extends OutletDevice {
 
   initDeviceServices() {
     this.createServiceByString('{"siid":2,"type":"urn:miot-spec-v2:service:switch:0000780C:cuco-cp1:1","description":"Switch"}');
-    this.createServiceByString('{"siid":3,"type":"urn:miot-spec-v2:service:indicator-light:00007803:cuco-cp1:2","description":"Indicator Light"}');
   }
 
   initDeviceProperties() {
     this.addPropertyByString('switch:on', '{"siid":2,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:cuco-cp1:1","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
-    this.addPropertyByString('indicator-light:on', '{"siid":3,"piid":1,"type":"urn:miot-spec-v2:property:on:00000006:cuco-cp1:2","description":"Switch Status","format":"bool","access":["read","write","notify"]}');
   }
 
   initDeviceActions() {


### PR DESCRIPTION
## What changed

Remove the unsupported `indicator-light` service and property from `cuco.plug.cp1`.

## Why

The CP1 device does not support `siid=3`. Including it in property polling caused the complete polling batch to fail, eventually stopping polling and breaking local control.

```
supported-siid-2-only
SUCCESS Response from device -> [{"siid":2,"piid":1,"code":0,"value":false}]

legacy-siid-2-plus-siid-3
ERROR Call to device timed out
```
## Validation

- `node --check` passed.
- `git diff --check` passed.
- Deployed to Homebridge on my local instance.
- Initial property fetch returned `switch:on` successfully.
- Subsequent polling completed without failures.
- Manual local control was verified successfully.