### PR TITLE
Convert propertyControl and propertyMonitor values to the property format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `value` and `linkedPropertyValue` of `propertyControl` / `propertyMonitor` entries are now converted to the format of the property. The Homebridge UI form stores them as strings, which made fixed value switches never report their state and sent string values to the device.
 
 ## [1.9.0] - 2026-07-24
 ### Added

--- a/lib/wrappers/AbstractPropertyWrapper.js
+++ b/lib/wrappers/AbstractPropertyWrapper.js
@@ -100,7 +100,7 @@ class AbstractPropertyWrapper {
 
 
   setFixedValue(fixedValue) {
-    this.fixedValue = fixedValue;
+    this.fixedValue = this._convertValueToPropFormat(fixedValue, this.getProp());
   }
 
   setFixedValueOperator(fixedValueOperator) {
@@ -112,7 +112,7 @@ class AbstractPropertyWrapper {
   }
 
   setLinkedPropFixedValue(linkedPropFixedValue) {
-    this.linkedPropFixedValue = linkedPropFixedValue;
+    this.linkedPropFixedValue = this._convertValueToPropFormat(linkedPropFixedValue, this.getLinkedProp());
   }
 
   setConfiguration(configuration) {
@@ -355,6 +355,29 @@ class AbstractPropertyWrapper {
 
   isMiotDeviceConnected() {
     return this.getDevice().isConnected();
+  }
+
+  // values coming from the user config (e.g. the Homebridge UI form) are strings, convert them to the format of the property so that strict comparisons and device writes work
+  _convertValueToPropFormat(value, prop) {
+    if (value === undefined || value === null || !prop || typeof value !== 'string') {
+      return value;
+    }
+
+    const format = prop.getFormat();
+    const trimmedValue = value.trim();
+
+    if (format === PropFormat.BOOL) {
+      if (trimmedValue.toLowerCase() === 'true') return true;
+      if (trimmedValue.toLowerCase() === 'false') return false;
+      return value;
+    }
+
+    const numericFormats = [PropFormat.INT, PropFormat.INT8, PropFormat.INT16, PropFormat.INT32, PropFormat.UINT8, PropFormat.UINT16, PropFormat.UINT32, PropFormat.FLOAT];
+    if (numericFormats.includes(format) && trimmedValue !== '' && Number.isFinite(Number(trimmedValue))) {
+      return Number(trimmedValue);
+    }
+
+    return value;
   }
 
 


### PR DESCRIPTION
**Where it comes from.** Homebridge UI → Plugins → Homebridge Miot → Plugin Config → device → *Property control* / *Property monitor*. In `config.schema.json` the `value` and `linkedPropertyValue` fields of both are declared `type: string`, so the form always saves strings. The README examples and hand-written configs use numbers.

**What breaks.** `AbstractPropertyWrapper` keeps the config value as is. `PropertyWrapper.isStatefulFixedValueSwitchOn()` and `checkLinkedPropStatus()` compare it with `===` against the numeric property value, and `setPropValue()` sends it to the device unchanged.

Saved by the form, broken:
```json
{ "property": "air-purifier:mode", "value": "1", "name": "Sleep" }
```
The switch never shows on (`1 !== "1"`) and turning it on sends `"1"` to the device.

Written by hand, works:
```json
{ "property": "air-purifier:mode", "value": 1, "name": "Sleep" }
```

**Fix.** `setFixedValue()` and `setLinkedPropFixedValue()` convert strings to the format of the target property: numeric formats become numbers, `bool` becomes boolean, other formats and non-numeric strings are kept as given. Both snippets above now behave the same; configs that already use numbers are unaffected.

**Verified** with `node --check`, a smoke `require('./index.js')`, a local `node:test` script against `PropertyWrapper` with a real `MiotProperty` (numeric, bool, string, non-numeric, linked value), and on a Mi Air Purifier 3C with the form-generated config.
